### PR TITLE
Implement reward CRUD management for loyalty admin

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -9,3 +9,92 @@
     padding: 16px;
     background: #f6f7f7;
 }
+
+.peopo-loyalty-admin {
+    max-width: 960px;
+}
+
+.peopo-loyalty-admin .notice {
+    margin-top: 16px;
+}
+
+.peopo-loyalty-admin__intro,
+.peopo-loyalty-admin__note {
+    font-size: 14px;
+    color: #50575e;
+    margin-bottom: 16px;
+}
+
+.peopo-loyalty-admin__grid {
+    display: grid;
+    gap: 24px;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.peopo-loyalty-admin__card {
+    background: #ffffff;
+    border: 1px solid #dcdcde;
+    border-radius: 8px;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+    padding: 24px;
+}
+
+.peopo-loyalty-admin__card header h2 {
+    margin: 0 0 8px;
+}
+
+.peopo-loyalty-admin__card header p {
+    margin: 0;
+    color: #50575e;
+}
+
+.peopo-loyalty-admin__form {
+    margin-top: 16px;
+}
+
+.peopo-loyalty-admin__field {
+    margin-bottom: 16px;
+}
+
+.peopo-loyalty-admin__label {
+    display: block;
+    font-weight: 600;
+    margin-bottom: 4px;
+}
+
+.peopo-loyalty-admin__table-actions {
+    white-space: nowrap;
+    text-align: right;
+}
+
+.peopo-loyalty-admin__table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 16px;
+}
+
+.peopo-loyalty-admin__table th,
+.peopo-loyalty-admin__table td {
+    padding: 12px;
+    border-top: 1px solid #dcdcde;
+    text-align: left;
+    vertical-align: top;
+}
+
+.peopo-loyalty-admin__table thead th {
+    border-top: none;
+    font-weight: 600;
+    background: #f6f7f7;
+}
+
+.peopo-loyalty-admin__points-label {
+    display: block;
+    font-size: 12px;
+    color: #646970;
+}
+
+.peopo-loyalty-admin__empty {
+    text-align: center;
+    padding: 32px 16px;
+    color: #50575e;
+}


### PR DESCRIPTION
## Summary
- add option-based storage for loyalty rewards and expose CRUD handlers on the admin screen
- replace the static reward idea layout with a manageable form and listing for reward catalog items
- enhance admin styles to support the new form layout, table actions, and empty states

## Testing
- php -l includes/class-peopo-plugin-loyalty.php

------
https://chatgpt.com/codex/tasks/task_e_68d7eed96110832b916217e0daa84118