### PR TITLE
Fix reward type selection and add voucher customer insights

### DIFF
--- a/assets/css/rewardx.css
+++ b/assets/css/rewardx.css
@@ -19,6 +19,33 @@
     gap: 1.5rem;
 }
 
+.rewardx-customer-insights {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+    margin-bottom: 1.5rem;
+    padding: 1rem 1.25rem;
+    background: #f7fafc;
+    border: 1px solid #e2e8f0;
+    border-radius: 12px;
+}
+
+.rewardx-customer-insights > div {
+    min-width: 180px;
+}
+
+.rewardx-insight-label {
+    display: block;
+    font-size: 0.85rem;
+    color: #4a5568;
+    margin-bottom: 0.25rem;
+}
+
+.rewardx-insight-value {
+    font-size: 1.15rem;
+    color: #1a202c;
+}
+
 .rewardx-card {
     position: relative;
     background: #fff;
@@ -181,5 +208,10 @@
     .rewardx-ledger-delta,
     .rewardx-ledger-balance {
         text-align: left;
+    }
+
+    .rewardx-customer-insights {
+        flex-direction: column;
+        gap: 1rem;
     }
 }

--- a/includes/Admin/class-admin.php
+++ b/includes/Admin/class-admin.php
@@ -121,6 +121,34 @@ class Admin
         update_post_meta($post_id, '_expiry_days', $expiry > 0 ? $expiry : 30);
         update_post_meta($post_id, '_stock', $stock);
         update_post_meta($post_id, '_sku', $sku);
+
+        $taxonomy = Reward_CPT::TAXONOMY;
+
+        if (isset($_POST['tax_input'][$taxonomy]) && is_array($_POST['tax_input'][$taxonomy])) {
+            $raw_terms    = wp_unslash($_POST['tax_input'][$taxonomy]);
+            $terms_to_set = [];
+
+            foreach ($raw_terms as $term_value) {
+                $term_value = sanitize_text_field($term_value);
+
+                if (is_numeric($term_value)) {
+                    $term = get_term((int) $term_value, $taxonomy);
+                    if ($term && !is_wp_error($term)) {
+                        $terms_to_set[] = $term->slug;
+                    }
+                } elseif ('' !== $term_value) {
+                    $terms_to_set[] = $term_value;
+                }
+            }
+
+            if (!empty($terms_to_set)) {
+                wp_set_post_terms($post_id, $terms_to_set, $taxonomy, false);
+            }
+        }
+
+        if (empty(wp_get_post_terms($post_id, $taxonomy, ['fields' => 'ids']))) {
+            wp_set_post_terms($post_id, ['physical'], $taxonomy, false);
+        }
     }
 
     public function manage_columns(array $columns): array

--- a/includes/CPT/class-reward-cpt.php
+++ b/includes/CPT/class-reward-cpt.php
@@ -76,8 +76,8 @@ class Reward_CPT
             return;
         }
 
-        $selected = wp_get_post_terms($post->ID, self::TAXONOMY, ['fields' => 'ids']);
-        $selected_id = $selected[0] ?? 0;
+        $selected = wp_get_post_terms($post->ID, self::TAXONOMY, ['fields' => 'slugs']);
+        $selected_slug = $selected[0] ?? 'physical';
 
         echo '<div class="rewardx-taxonomy-field">';
         echo '<p>' . esc_html__('Chọn loại phần thưởng', 'woo-rewardx-lite') . '</p>';
@@ -85,8 +85,8 @@ class Reward_CPT
         foreach ($terms as $term) {
             printf(
                 '<option value="%1$s" %2$s>%3$s</option>',
-                esc_attr($term->term_id),
-                selected($selected_id, $term->term_id, false),
+                esc_attr($term->slug),
+                selected($selected_slug, $term->slug, false),
                 esc_html($term->name)
             );
         }

--- a/includes/Frontend/class-frontend.php
+++ b/includes/Frontend/class-frontend.php
@@ -88,11 +88,13 @@ class Frontend
             return;
         }
 
-        $user_id  = get_current_user_id();
-        $points   = $this->points_manager->get_points($user_id);
-        $ledger   = $this->points_manager->get_recent_transactions($user_id, 10);
-        $settings = Plugin::instance()->get_settings()->get_settings();
-        $rewards  = $this->get_rewards();
+        $user_id     = get_current_user_id();
+        $points      = $this->points_manager->get_points($user_id);
+        $ledger      = $this->points_manager->get_recent_transactions($user_id, 10);
+        $settings    = Plugin::instance()->get_settings()->get_settings();
+        $rewards     = $this->get_rewards();
+        $total_spent = function_exists('wc_get_customer_total_spent') ? (float) wc_get_customer_total_spent($user_id) : 0.0;
+        $order_count = function_exists('wc_get_customer_order_count') ? (int) wc_get_customer_order_count($user_id) : 0;
 
         include REWARDX_PATH . 'includes/views/account-rewardx.php';
     }

--- a/includes/views/account-rewardx.php
+++ b/includes/views/account-rewardx.php
@@ -42,6 +42,16 @@ $voucher_rewards  = $rewards['voucher'] ?? [];
     <?php if (!empty($voucher_rewards)) : ?>
         <section class="rewardx-section">
             <h3><?php esc_html_e('Voucher', 'woo-rewardx-lite'); ?></h3>
+            <div class="rewardx-customer-insights">
+                <div>
+                    <span class="rewardx-insight-label"><?php esc_html_e('Tổng giá trị đơn hàng đã mua', 'woo-rewardx-lite'); ?></span>
+                    <strong class="rewardx-insight-value"><?php echo wp_kses_post(function_exists('wc_price') ? wc_price($total_spent) : number_format_i18n($total_spent, 2)); ?></strong>
+                </div>
+                <div>
+                    <span class="rewardx-insight-label"><?php esc_html_e('Số đơn hàng đã hoàn tất', 'woo-rewardx-lite'); ?></span>
+                    <strong class="rewardx-insight-value"><?php echo esc_html(number_format_i18n($order_count)); ?></strong>
+                </div>
+            </div>
             <div class="rewardx-grid">
                 <?php foreach ($voucher_rewards as $item) : ?>
                     <article class="rewardx-card" data-reward-id="<?php echo esc_attr($item['id']); ?>" data-type="voucher" data-cost="<?php echo esc_attr($item['cost']); ?>">


### PR DESCRIPTION
## Summary
- ensure reward type taxonomy saves using slugs and default to physical when missing
- expose voucher redemption insights by showing total spend and completed order count
- style the new voucher insight block on the account page

## Testing
- php -l includes/CPT/class-reward-cpt.php
- php -l includes/Admin/class-admin.php
- php -l includes/Frontend/class-frontend.php
- php -l includes/views/account-rewardx.php

------
https://chatgpt.com/codex/tasks/task_e_68d81234de14832b9812c4e911b832f2