### PR TITLE
Handle missing WooCommerce dependency gracefully

### DIFF
--- a/woo-rewardx-lite.php
+++ b/woo-rewardx-lite.php
@@ -25,6 +25,54 @@ require_once REWARDX_PATH . 'includes/class-rewardx-plugin.php';
 register_activation_hook(__FILE__, ['RewardX\\Plugin', 'activate']);
 register_deactivation_hook(__FILE__, ['RewardX\\Plugin', 'deactivate']);
 
+if (!function_exists('rewardx_lite_dependencies_met')) {
+    function rewardx_lite_dependencies_met(): bool
+    {
+        return class_exists('WooCommerce', false) || did_action('woocommerce_loaded');
+    }
+}
+
+if (!function_exists('rewardx_lite_missing_wc_notice')) {
+    function rewardx_lite_missing_wc_notice(): void
+    {
+        if (!current_user_can('activate_plugins')) {
+            return;
+        }
+
+        echo '<div class="notice notice-error"><p>' . esc_html__('Woo RewardX Lite yêu cầu WooCommerce đang hoạt động. Plugin đã bị vô hiệu hóa.', 'woo-rewardx-lite') . '</p></div>';
+    }
+}
+
+if (!function_exists('rewardx_lite_handle_missing_dependencies')) {
+    function rewardx_lite_handle_missing_dependencies(): void
+    {
+        if (!is_admin()) {
+            return;
+        }
+
+        add_action('admin_notices', 'rewardx_lite_missing_wc_notice');
+        add_action('network_admin_notices', 'rewardx_lite_missing_wc_notice');
+
+        add_action('admin_init', static function (): void {
+            if (!current_user_can('activate_plugins')) {
+                return;
+            }
+
+            if (!function_exists('deactivate_plugins')) {
+                require_once ABSPATH . 'wp-admin/includes/plugin.php';
+            }
+
+            deactivate_plugins(REWARDX_BASENAME);
+        });
+    }
+}
+
 add_action('plugins_loaded', static function (): void {
+    if (!rewardx_lite_dependencies_met()) {
+        rewardx_lite_handle_missing_dependencies();
+
+        return;
+    }
+
     RewardX\Plugin::instance()->boot();
 });


### PR DESCRIPTION
## Summary
- add a runtime dependency guard that prevents the plugin from booting when WooCommerce is inactive
- automatically deactivate the plugin and surface an admin notice so the site stays accessible instead of timing out

## Testing
- php -l woo-rewardx-lite.php

------
https://chatgpt.com/codex/tasks/task_e_68d820190f9c832b9f4a0d2306b639e7