### PR TITLE
Cải tiến giao diện đổi thưởng cho người dùng

### DIFF
--- a/assets/css/rewardx.css
+++ b/assets/css/rewardx.css
@@ -47,6 +47,95 @@
     margin-bottom: 3rem;
 }
 
+.rewardx-toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 1.75rem;
+    flex-wrap: wrap;
+}
+
+.rewardx-tabs {
+    display: inline-flex;
+    align-items: center;
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+    border-radius: 999px;
+    padding: 0.25rem;
+    gap: 0.25rem;
+}
+
+.rewardx-tabs--single {
+    background: transparent;
+    border: none;
+    padding: 0;
+}
+
+.rewardx-tab {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: none;
+    background: transparent;
+    color: #475569;
+    font-weight: 600;
+    font-size: 0.9rem;
+    padding: 0.45rem 1.2rem;
+    border-radius: 999px;
+    cursor: pointer;
+    transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.rewardx-tabs--single .rewardx-tab {
+    cursor: default;
+    color: #0f172a;
+    font-size: 1rem;
+}
+
+.rewardx-tab.is-active {
+    background: linear-gradient(135deg, rgba(37, 99, 235, 0.14), rgba(37, 99, 235, 0.35));
+    color: #1d4ed8;
+    box-shadow: 0 8px 18px rgba(37, 99, 235, 0.18);
+}
+
+.rewardx-tab:focus-visible {
+    outline: 2px solid #2563eb;
+    outline-offset: 2px;
+}
+
+.rewardx-filter {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.95rem;
+    color: #334155;
+    font-weight: 500;
+    cursor: pointer;
+    user-select: none;
+}
+
+.rewardx-filter-toggle {
+    width: 18px;
+    height: 18px;
+    accent-color: #2563eb;
+}
+
+.rewardx-section--hidden {
+    display: none;
+}
+
+.rewardx-card--hidden {
+    display: none;
+}
+
+.rewardx-empty-filter {
+    text-align: center;
+    margin: 1.5rem 0 0;
+    color: #475569;
+    font-size: 0.95rem;
+}
+
 .rewardx-section-header {
     display: flex;
     align-items: flex-end;
@@ -397,6 +486,25 @@
 @media (max-width: 768px) {
     .rewardx-account {
         padding: 0 1rem 2.5rem;
+    }
+
+    .rewardx-toolbar {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 0.75rem;
+    }
+
+    .rewardx-tabs {
+        width: 100%;
+        justify-content: space-between;
+    }
+
+    .rewardx-filter {
+        width: 100%;
+        justify-content: space-between;
+        background: #f1f5f9;
+        padding: 0.75rem 1rem;
+        border-radius: 12px;
     }
 
     .rewardx-card-meta {


### PR DESCRIPTION
## Summary
- thêm thanh điều hướng và bộ lọc giúp người dùng duyệt phần thưởng trực quan hơn
- cập nhật giao diện thẻ thưởng, trạng thái và thông báo rỗng phù hợp với bộ lọc mới
- đồng bộ javascript để bật/tắt tab, lọc phần thưởng theo điểm khả dụng và cập nhật trạng thái sau khi đổi thưởng

## Testing
- php -l includes/views/account-rewardx.php

------
https://chatgpt.com/codex/tasks/task_e_68d8e1c78ac0832b844d877d65f09863