### PR TITLE
Revamp loyalty account front end

### DIFF
--- a/assets/css/rewardx.css
+++ b/assets/css/rewardx.css
@@ -1,146 +1,179 @@
 .rewardx-account {
-    max-width: 1200px;
-    margin: 3rem auto;
-    padding: 0 1.5rem 4rem;
-    color: #0f172a;
+    --rx-bg: #f8fafc;
+    --rx-surface: #ffffff;
+    --rx-border: rgba(148, 163, 184, 0.35);
+    --rx-muted: #64748b;
+    --rx-muted-soft: #94a3b8;
+    --rx-ink: #0f172a;
+    --rx-accent: #2563eb;
+    --rx-accent-soft: rgba(37, 99, 235, 0.08);
+    --rx-positive: #059669;
+    --rx-danger: #dc2626;
+    --rx-shadow: 0 30px 60px rgba(15, 23, 42, 0.08);
+    max-width: 1120px;
+    margin: 0 auto;
+    padding: 3rem 1.5rem 4rem;
+    color: var(--rx-ink);
+    background: linear-gradient(180deg, rgba(241, 245, 249, 0.9), rgba(255, 255, 255, 0.9));
+    border-radius: 32px;
+    box-shadow: 0 45px 80px rgba(15, 23, 42, 0.12);
+    backdrop-filter: blur(16px);
 }
 
-.rewardx-hero {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 2rem;
-    padding: 2.75rem;
-    border-radius: 28px;
-    background: radial-gradient(110% 140% at 0% 0%, rgba(37, 99, 235, 0.12) 0%, rgba(14, 165, 233, 0.05) 45%, rgba(255, 255, 255, 1) 100%);
-    border: 1px solid rgba(148, 163, 184, 0.35);
-    box-shadow: 0 30px 60px rgba(15, 23, 42, 0.08);
+.rewardx-account * {
+    box-sizing: border-box;
+}
+
+.rewardx-overview {
+    display: grid;
+    gap: 2.5rem;
     margin-bottom: 3rem;
-    flex-wrap: wrap;
 }
 
-.rewardx-hero-summary {
-    max-width: 420px;
+.rewardx-overview-header {
+    max-width: 520px;
+    display: grid;
+    gap: 0.75rem;
 }
 
-.rewardx-hero-label {
-    font-size: 0.85rem;
+.rewardx-eyebrow {
+    font-size: 0.75rem;
+    letter-spacing: 0.16em;
     text-transform: uppercase;
-    letter-spacing: 0.12em;
-    color: #1d4ed8;
+    color: var(--rx-accent);
     font-weight: 600;
-    margin: 0 0 0.85rem;
 }
 
-.rewardx-points {
-    font-size: 3.5rem;
-    font-weight: 700;
-    color: #1e3a8a;
+.rewardx-headline {
     margin: 0;
-    line-height: 1;
+    font-size: clamp(1.9rem, 1.5rem + 1.5vw, 2.6rem);
+    font-weight: 700;
 }
 
-.rewardx-hero-hint {
-    margin: 1rem 0 0;
-    color: #475569;
-    font-size: 1rem;
+.rewardx-description {
+    margin: 0;
+    color: var(--rx-muted);
     line-height: 1.7;
 }
 
-.rewardx-hero-stats {
+.rewardx-overview-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-    gap: 1rem;
-    margin: 0;
-    padding: 0;
-    list-style: none;
-    flex: 1;
-    min-width: 260px;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.5rem;
 }
 
-.rewardx-hero-stats li {
+.rewardx-overview-card {
     position: relative;
-    padding: 1.1rem 1.25rem;
-    border-radius: 18px;
-    background: rgba(255, 255, 255, 0.9);
-    border: 1px solid rgba(148, 163, 184, 0.3);
-    box-shadow: 0 18px 35px rgba(15, 23, 42, 0.08);
+    padding: 1.75rem;
+    border-radius: 22px;
+    background: var(--rx-surface);
+    border: 1px solid var(--rx-border);
+    box-shadow: var(--rx-shadow);
+    display: grid;
+    gap: 0.75rem;
+    overflow: hidden;
+    transition: transform 0.25s ease, box-shadow 0.25s ease;
 }
 
-.rewardx-stat-label {
-    display: block;
-    font-size: 0.8rem;
+.rewardx-overview-card::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(120% 120% at 0% 0%, rgba(37, 99, 235, 0.08), transparent 65%);
+    opacity: 0;
+    transition: opacity 0.25s ease;
+}
+
+.rewardx-overview-card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 40px 70px rgba(15, 23, 42, 0.12);
+}
+
+.rewardx-overview-card:hover::after {
+    opacity: 1;
+}
+
+.rewardx-overview-card header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.rewardx-overview-card--balance {
+    background: linear-gradient(135deg, rgba(37, 99, 235, 0.14), rgba(14, 165, 233, 0.08));
+    border: 1px solid rgba(59, 130, 246, 0.25);
+}
+
+.rewardx-overview-card--balance .rewardx-overview-value {
+    color: #1d4ed8;
+}
+
+.rewardx-overview-label {
+    font-size: 0.85rem;
+    letter-spacing: 0.1em;
     text-transform: uppercase;
-    letter-spacing: 0.08em;
-    color: #64748b;
-    margin-bottom: 0.4rem;
+    color: var(--rx-muted-soft);
+    font-weight: 600;
 }
 
-.rewardx-stat-value {
-    display: block;
-    font-size: 1.75rem;
+.rewardx-overview-value {
+    font-size: 2.4rem;
     font-weight: 700;
-    color: #0f172a;
-}
-
-.rewardx-stat-value--success {
-    color: #047857;
-}
-
-.rewardx-stat-value--muted {
-    color: #64748b;
-}
-
-.rewardx-stat-value--alert {
-    color: #b91c1c;
-}
-
-.rewardx-empty {
-    background: linear-gradient(135deg, rgba(59, 130, 246, 0.12), rgba(16, 185, 129, 0.12));
-    border: 1px solid rgba(148, 163, 184, 0.4);
-    border-radius: 16px;
-    padding: 2rem;
-    text-align: center;
-    margin-bottom: 2.5rem;
-}
-
-.rewardx-empty h3 {
-    margin-bottom: 0.5rem;
-    font-size: 1.25rem;
-    color: #0f172a;
-}
-
-.rewardx-empty p {
     margin: 0;
-    color: #475569;
+}
+
+.rewardx-overview-subtext {
+    margin: 0;
+    font-size: 0.95rem;
+    color: var(--rx-muted);
+    line-height: 1.6;
 }
 
 .rewardx-section {
+    display: grid;
+    gap: 1.75rem;
     margin-bottom: 3rem;
+}
+
+.rewardx-section-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1.5rem;
+    flex-wrap: wrap;
+}
+
+.rewardx-section-header h3 {
+    margin: 0;
+    font-size: 1.6rem;
+    font-weight: 700;
+}
+
+.rewardx-section-header p {
+    margin: 0.4rem 0 0;
+    color: var(--rx-muted);
 }
 
 .rewardx-toolbar {
     display: flex;
     align-items: center;
-    justify-content: space-between;
     gap: 1.25rem;
-    margin-bottom: 2.25rem;
-    flex-wrap: wrap;
-    background: rgba(255, 255, 255, 0.95);
-    border: 1px solid rgba(148, 163, 184, 0.35);
+    background: rgba(255, 255, 255, 0.92);
+    border: 1px solid var(--rx-border);
     border-radius: 18px;
-    padding: 1.1rem 1.5rem;
-    box-shadow: 0 18px 35px rgba(15, 23, 42, 0.08);
+    padding: 0.75rem 1rem;
+    box-shadow: var(--rx-shadow);
+    flex-wrap: wrap;
 }
 
 .rewardx-tabs {
     display: inline-flex;
     align-items: center;
-    background: rgba(241, 245, 249, 0.8);
-    border: 1px solid rgba(226, 232, 240, 0.8);
-    border-radius: 14px;
-    padding: 0.35rem;
     gap: 0.35rem;
+    padding: 0.35rem;
+    border-radius: 999px;
+    background: rgba(241, 245, 249, 0.85);
+    border: 1px solid rgba(203, 213, 225, 0.7);
 }
 
 .rewardx-tabs--single {
@@ -153,32 +186,31 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    padding: 0.55rem 1.4rem;
+    border-radius: 999px;
     border: none;
     background: transparent;
-    color: #475569;
+    color: var(--rx-muted);
     font-weight: 600;
     font-size: 0.95rem;
-    padding: 0.55rem 1.4rem;
-    border-radius: 12px;
     cursor: pointer;
-    transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+    transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .rewardx-tabs--single .rewardx-tab {
     cursor: default;
-    color: #0f172a;
-    font-size: 1rem;
+    color: var(--rx-ink);
 }
 
 .rewardx-tab.is-active {
     background: #fff;
-    color: #1d4ed8;
-    box-shadow: 0 10px 22px rgba(37, 99, 235, 0.18);
+    color: var(--rx-accent);
+    box-shadow: 0 12px 24px rgba(37, 99, 235, 0.25);
     transform: translateY(-1px);
 }
 
 .rewardx-tab:focus-visible {
-    outline: 2px solid #2563eb;
+    outline: 2px solid var(--rx-accent);
     outline-offset: 2px;
 }
 
@@ -186,10 +218,10 @@
     position: relative;
     display: inline-flex;
     align-items: center;
-    gap: 0.75rem;
+    gap: 0.65rem;
     font-size: 0.95rem;
-    color: #0f172a;
     font-weight: 500;
+    color: var(--rx-ink);
     cursor: pointer;
     user-select: none;
 }
@@ -201,30 +233,28 @@
 }
 
 .rewardx-filter-switch {
-    position: relative;
-    width: 44px;
-    height: 24px;
+    width: 46px;
+    height: 26px;
+    background: rgba(148, 163, 184, 0.4);
     border-radius: 999px;
-    background: #e2e8f0;
-    transition: background 0.25s ease, box-shadow 0.25s ease;
-    box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.4);
+    padding: 3px;
+    display: inline-flex;
+    align-items: center;
+    transition: background 0.2s ease;
 }
 
 .rewardx-filter-knob {
-    position: absolute;
-    top: 3px;
-    left: 3px;
-    width: 18px;
-    height: 18px;
+    width: 20px;
+    height: 20px;
     border-radius: 50%;
     background: #fff;
-    box-shadow: 0 6px 14px rgba(15, 23, 42, 0.2);
-    transition: transform 0.25s ease;
+    box-shadow: 0 8px 14px rgba(15, 23, 42, 0.15);
+    transform: translateX(0);
+    transition: transform 0.2s ease;
 }
 
 .rewardx-filter-toggle:checked + .rewardx-filter-switch {
-    background: linear-gradient(135deg, #2563eb, #7c3aed);
-    box-shadow: 0 10px 20px rgba(79, 70, 229, 0.25);
+    background: var(--rx-accent);
 }
 
 .rewardx-filter-toggle:checked + .rewardx-filter-switch .rewardx-filter-knob {
@@ -232,110 +262,80 @@
 }
 
 .rewardx-filter-toggle:focus-visible + .rewardx-filter-switch {
-    outline: 2px solid #2563eb;
-    outline-offset: 3px;
+    outline: 2px solid var(--rx-accent);
+    outline-offset: 2px;
 }
 
 .rewardx-filter-text {
-    white-space: nowrap;
+    color: var(--rx-muted);
+}
+
+.rewardx-section-body {
+    display: grid;
+    gap: 1.5rem;
+}
+
+.rewardx-subsection-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+}
+
+.rewardx-subsection-header h4 {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 600;
+}
+
+.rewardx-subsection-header p {
+    margin: 0;
+    color: var(--rx-muted);
 }
 
 .rewardx-section--hidden {
     display: none;
 }
 
-.rewardx-card--hidden {
-    display: none;
-}
-
-.rewardx-empty-filter {
-    text-align: center;
-    margin: 1.5rem 0 0;
-    color: #475569;
-    font-size: 0.95rem;
-}
-
-.rewardx-section-header {
-    display: flex;
-    align-items: flex-end;
-    justify-content: space-between;
-    gap: 1rem;
-    margin-bottom: 1.5rem;
-}
-
-.rewardx-section-header h3 {
-    font-size: 1.5rem;
-    margin: 0 0 0.5rem;
-    color: #0f172a;
-}
-
-.rewardx-section-header p {
-    margin: 0;
-    color: #475569;
-}
-
 .rewardx-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
-    gap: 2rem;
-}
-
-.rewardx-customer-insights {
-    display: flex;
-    flex-wrap: wrap;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
     gap: 1.5rem;
-    margin-bottom: 2rem;
-    padding: 1.5rem 1.75rem;
-    background: linear-gradient(135deg, rgba(241, 245, 249, 0.9), rgba(255, 255, 255, 0.9));
-    border: 1px solid rgba(226, 232, 240, 0.8);
-    border-radius: 20px;
-    box-shadow: 0 16px 32px rgba(15, 23, 42, 0.08);
-}
-
-.rewardx-customer-insights > div {
-    min-width: 200px;
-}
-
-.rewardx-insight-label {
-    display: block;
-    font-size: 0.85rem;
-    color: #64748b;
-    margin-bottom: 0.35rem;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-}
-
-.rewardx-insight-value {
-    font-size: 1.35rem;
-    font-weight: 600;
-    color: #0f172a;
 }
 
 .rewardx-card {
-    position: relative;
-    background: linear-gradient(#ffffff, #ffffff) padding-box, linear-gradient(135deg, rgba(37, 99, 235, 0.18), rgba(14, 165, 233, 0.15)) border-box;
-    border-radius: 22px;
-    box-shadow: 0 22px 45px rgba(15, 23, 42, 0.12);
-    border: 1px solid transparent;
-    display: flex;
-    flex-direction: column;
-    overflow: hidden;
-    transition: transform 0.25s ease, box-shadow 0.25s ease;
+    display: grid;
+    gap: 1.25rem;
+    padding: 1.6rem;
+    border-radius: 20px;
+    background: #ffffff;
+    border: 1px solid rgba(226, 232, 240, 0.8);
+    box-shadow: 0 25px 60px rgba(15, 23, 42, 0.07);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .rewardx-card:hover {
     transform: translateY(-6px);
-    box-shadow: 0 28px 55px rgba(15, 23, 42, 0.16);
+    box-shadow: 0 35px 70px rgba(15, 23, 42, 0.12);
+}
+
+.rewardx-card-top {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    gap: 1rem;
+    align-items: center;
 }
 
 .rewardx-card-media {
-    position: relative;
-    background: radial-gradient(circle at top left, rgba(37, 99, 235, 0.55), rgba(14, 165, 233, 0.35));
-    height: 190px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+    width: 72px;
+    height: 72px;
+    border-radius: 18px;
+    background: rgba(226, 232, 240, 0.6);
+    display: grid;
+    place-items: center;
     overflow: hidden;
+    font-size: 1.75rem;
 }
 
 .rewardx-card-media img {
@@ -344,152 +344,145 @@
     object-fit: cover;
 }
 
-.rewardx-card-media--empty::after {
-    content: '🎁';
-    font-family: inherit;
-    font-size: 2.5rem;
-    color: rgba(255, 255, 255, 0.85);
+.rewardx-card-media--empty {
+    background: rgba(203, 213, 225, 0.4);
 }
 
-.rewardx-badge {
-    position: absolute;
-    top: 1rem;
-    left: 1rem;
-    padding: 0.4rem 0.85rem;
-    border-radius: 999px;
-    font-size: 0.75rem;
-    color: #fff;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    background: rgba(15, 23, 42, 0.35);
-    backdrop-filter: blur(6px);
-}
-
-.rewardx-badge-physical {
-    background: rgba(22, 163, 74, 0.85);
-}
-
-.rewardx-badge-voucher {
-    background: rgba(217, 70, 239, 0.85);
-}
-
-.rewardx-card-body {
-    padding: 1.75rem 1.75rem 0;
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
-    flex: 1;
+.rewardx-card-headline {
+    display: grid;
+    gap: 0.45rem;
 }
 
 .rewardx-card-title {
-    font-size: 1.25rem;
     margin: 0;
-    color: #0f172a;
+    font-size: 1.1rem;
+    font-weight: 600;
 }
 
 .rewardx-card-description {
-    color: #475569;
     margin: 0;
-    line-height: 1.6;
+    color: var(--rx-muted);
+    line-height: 1.5;
+    font-size: 0.95rem;
+}
+
+.rewardx-badge {
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    background: rgba(59, 130, 246, 0.12);
+    color: #1d4ed8;
+}
+
+.rewardx-badge-physical {
+    background: rgba(14, 165, 233, 0.12);
+    color: #0ea5e9;
+}
+
+.rewardx-badge-voucher {
+    background: rgba(244, 114, 182, 0.12);
+    color: #db2777;
 }
 
 .rewardx-card-meta {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-    gap: 0.75rem;
-    margin: 0;
+    gap: 0.85rem;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
 }
 
 .rewardx-card-meta-item {
-    background: rgba(241, 245, 249, 0.7);
-    border-radius: 14px;
-    padding: 0.9rem 1.1rem;
+    display: grid;
+    gap: 0.35rem;
 }
 
-.rewardx-card-meta-item dt {
-    margin: 0 0 0.4rem;
+.rewardx-card-meta-label {
     font-size: 0.75rem;
     text-transform: uppercase;
-    letter-spacing: 0.08em;
-    color: #94a3b8;
+    letter-spacing: 0.12em;
+    color: var(--rx-muted-soft);
+    font-weight: 600;
 }
 
-.rewardx-card-meta-item dd {
-    margin: 0;
-    font-size: 0.95rem;
+.rewardx-card-meta-value {
+    font-size: 1rem;
     font-weight: 600;
-    color: #0f172a;
+    color: var(--rx-ink);
 }
 
 .rewardx-card-highlight {
-    color: #2563eb;
+    color: var(--rx-accent);
 }
 
 .rewardx-chip {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    min-width: 64px;
-    padding: 0.25rem 0.6rem;
+    padding: 0.35rem 0.75rem;
     border-radius: 999px;
-    font-size: 0.8rem;
-    background: rgba(37, 99, 235, 0.1);
-    color: #1d4ed8;
+    background: rgba(226, 232, 240, 0.6);
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--rx-ink);
 }
 
 .rewardx-chip--soft {
-    background: rgba(16, 185, 129, 0.15);
+    background: rgba(16, 185, 129, 0.12);
     color: #047857;
 }
 
 .rewardx-chip--danger {
     background: rgba(239, 68, 68, 0.12);
-    color: #b91c1c;
+    color: var(--rx-danger);
 }
 
 .rewardx-card-footer {
-    padding: 1.5rem 1.75rem 1.75rem;
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
+    display: grid;
+    gap: 0.6rem;
 }
 
 .rewardx-redeem {
-    align-self: flex-start;
-    background: linear-gradient(135deg, #2563eb, #7c3aed);
-    color: #fff;
+    width: 100%;
+    justify-self: flex-start;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    background: var(--rx-accent);
     border: none;
-    padding: 0.8rem 1.9rem;
     border-radius: 999px;
-    cursor: pointer;
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    padding: 0.7rem 1.5rem;
+    color: #fff;
     font-weight: 600;
-    box-shadow: 0 16px 30px rgba(79, 70, 229, 0.28);
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
 
 .rewardx-redeem:hover:not(:disabled) {
-    transform: translateY(-3px);
-    box-shadow: 0 20px 36px rgba(79, 70, 229, 0.32);
+    transform: translateY(-2px);
+    box-shadow: 0 18px 36px rgba(37, 99, 235, 0.3);
+    background: #1d4ed8;
 }
 
 .rewardx-redeem:disabled {
-    opacity: 0.5;
+    opacity: 0.55;
     cursor: not-allowed;
     box-shadow: none;
 }
 
 .rewardx-card-note {
-    font-size: 0.85rem;
-    color: #475569;
+    font-size: 0.9rem;
+    color: var(--rx-muted);
 }
 
 .rewardx-card-note--danger {
-    color: #b91c1c;
+    color: var(--rx-danger);
 }
 
 .rewardx-card-note--success {
-    color: #047857;
+    color: var(--rx-positive);
 }
 
 .rewardx-card-progress {
@@ -497,128 +490,164 @@
     align-items: baseline;
     gap: 0.35rem;
     font-size: 0.9rem;
-    color: #1d4ed8;
-    font-weight: 600;
+    color: var(--rx-muted);
 }
 
-.rewardx-card-progress-label {
-    text-transform: uppercase;
-    font-size: 0.75rem;
+.rewardx-card-progress-label,
+.rewardx-card-progress-suffix {
+    font-size: 0.8rem;
     letter-spacing: 0.08em;
-    color: #64748b;
+    text-transform: uppercase;
+    color: var(--rx-muted-soft);
 }
 
 .rewardx-card-progress-value {
-    font-size: 1.1rem;
-    color: #1d4ed8;
+    font-weight: 700;
+    color: var(--rx-accent);
 }
 
-.rewardx-card-progress-suffix {
-    font-size: 0.85rem;
-    color: #475569;
+.rewardx-card--hidden {
+    display: none;
+}
+
+.rewardx-empty {
+    text-align: center;
+    background: rgba(226, 232, 240, 0.5);
+    border-radius: 20px;
+    padding: 2.5rem 2rem;
+    border: 1px dashed rgba(148, 163, 184, 0.6);
+}
+
+.rewardx-empty h4 {
+    margin: 0 0 0.75rem;
+    font-size: 1.25rem;
+}
+
+.rewardx-empty p {
+    margin: 0;
+    color: var(--rx-muted);
+}
+
+.rewardx-empty-filter {
+    margin: 0;
+    text-align: center;
+    font-size: 0.95rem;
+    color: var(--rx-muted);
+}
+
+.rewardx-section--history .rewardx-section-header {
+    margin-bottom: 0.75rem;
 }
 
 .rewardx-ledger {
     list-style: none;
-    padding: 0;
     margin: 0;
-    border: 1px solid #e2e8f0;
-    border-radius: 16px;
+    padding: 0;
+    border-radius: 18px;
+    border: 1px solid rgba(226, 232, 240, 0.8);
     overflow: hidden;
-    background: #fff;
+    box-shadow: 0 25px 55px rgba(15, 23, 42, 0.08);
 }
 
 .rewardx-ledger-head,
 .rewardx-ledger-row {
     display: grid;
-    grid-template-columns: 1.2fr 2fr 0.8fr 0.8fr;
+    grid-template-columns: 1.1fr 1.4fr 0.7fr 0.7fr;
     gap: 1rem;
-    padding: 1rem 1.25rem;
+    padding: 1rem 1.5rem;
     align-items: center;
 }
 
 .rewardx-ledger-head {
-    background: #f1f5f9;
-    font-weight: 600;
-    color: #0f172a;
+    background: rgba(226, 232, 240, 0.6);
+    font-size: 0.8rem;
+    letter-spacing: 0.14em;
     text-transform: uppercase;
-    font-size: 0.75rem;
-    letter-spacing: 0.06em;
+    color: var(--rx-muted-soft);
+    font-weight: 600;
 }
 
-.rewardx-ledger-row {
-    border-top: 1px solid #e2e8f0;
+.rewardx-ledger-row:nth-child(even) {
+    background: rgba(248, 250, 252, 0.9);
 }
 
-.rewardx-ledger-empty {
-    padding: 1.5rem;
-    text-align: center;
-    color: #475569;
+.rewardx-ledger-row span {
+    font-size: 0.95rem;
+    color: var(--rx-ink);
 }
 
 .rewardx-ledger-delta {
-    font-weight: 700;
-    text-align: right;
+    font-weight: 600;
 }
 
 .rewardx-ledger-delta.positive {
-    color: #16a34a;
+    color: var(--rx-positive);
 }
 
 .rewardx-ledger-delta.negative {
-    color: #dc2626;
+    color: var(--rx-danger);
+}
+
+.rewardx-ledger-empty {
+    padding: 1.75rem;
+    text-align: center;
+    color: var(--rx-muted);
 }
 
 .rewardx-modal {
     position: fixed;
     inset: 0;
-    background: rgba(15, 23, 42, 0.55);
-    display: none;
+    background: rgba(15, 23, 42, 0.35);
+    display: flex;
     align-items: center;
     justify-content: center;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease;
     z-index: 9999;
-    padding: 1.5rem;
 }
 
 .rewardx-modal.show {
-    display: flex;
+    opacity: 1;
+    pointer-events: auto;
 }
 
 .rewardx-modal-content {
     background: #fff;
     border-radius: 18px;
-    padding: 2.25rem 2rem;
-    max-width: 460px;
-    width: 100%;
+    max-width: 420px;
+    width: calc(100% - 2rem);
+    padding: 2rem 2.5rem;
     position: relative;
-    text-align: center;
-    box-shadow: 0 25px 45px rgba(15, 23, 42, 0.15);
+    box-shadow: 0 45px 80px rgba(15, 23, 42, 0.2);
 }
 
 .rewardx-modal-close {
     position: absolute;
-    top: 0.85rem;
-    right: 0.85rem;
+    top: 0.75rem;
+    right: 0.75rem;
     border: none;
-    background: transparent;
-    font-size: 1.75rem;
+    background: rgba(226, 232, 240, 0.8);
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    font-size: 1.25rem;
     cursor: pointer;
-    color: #475569;
 }
 
 .rewardx-toast {
     position: fixed;
-    bottom: 1.5rem;
-    right: 1.5rem;
-    background: linear-gradient(135deg, #2563eb, #7c3aed);
+    bottom: 2rem;
+    right: 2rem;
+    background: #0f172a;
     color: #fff;
-    padding: 0.85rem 1.75rem;
-    border-radius: 999px;
-    box-shadow: 0 18px 35px rgba(37, 99, 235, 0.35);
+    padding: 0.85rem 1.4rem;
+    border-radius: 14px;
+    box-shadow: 0 20px 40px rgba(15, 23, 42, 0.25);
+    transform: translateY(30px);
     opacity: 0;
-    transform: translateY(20px);
     transition: opacity 0.2s ease, transform 0.2s ease;
-    z-index: 9999;
+    z-index: 10000;
 }
 
 .rewardx-toast.show {
@@ -626,37 +655,56 @@
     transform: translateY(0);
 }
 
-@media (max-width: 1024px) {
-    .rewardx-section-header {
-        flex-direction: column;
-        align-items: flex-start;
-    }
-
-    .rewardx-hero {
-        flex-direction: column;
-        align-items: flex-start;
-        padding: 2.25rem;
-    }
-
-    .rewardx-hero-stats {
-        width: 100%;
-        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-    }
-}
-
-@media (max-width: 768px) {
+@media (max-width: 900px) {
     .rewardx-account {
-        padding: 0 1rem 2.5rem;
+        padding: 2.5rem 1.25rem 3.5rem;
     }
 
-    .rewardx-hero {
-        padding: 2rem;
+    .rewardx-card-top {
+        grid-template-columns: minmax(0, 1fr);
+        justify-items: start;
+    }
+
+    .rewardx-card-media {
+        width: 64px;
+        height: 64px;
+    }
+
+    .rewardx-card {
+        padding: 1.4rem;
     }
 
     .rewardx-toolbar {
+        width: 100%;
+        justify-content: space-between;
+    }
+
+    .rewardx-ledger-head,
+    .rewardx-ledger-row {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 0.75rem;
+    }
+
+    .rewardx-ledger-head span:nth-child(n + 3),
+    .rewardx-ledger-row span:nth-child(n + 3) {
+        justify-self: end;
+    }
+}
+
+@media (max-width: 640px) {
+    .rewardx-account {
+        border-radius: 20px;
+    }
+
+    .rewardx-section-header,
+    .rewardx-toolbar {
         flex-direction: column;
         align-items: stretch;
-        gap: 0.75rem;
+    }
+
+    .rewardx-filter {
+        justify-content: space-between;
+        width: 100%;
     }
 
     .rewardx-tabs {
@@ -664,66 +712,38 @@
         justify-content: space-between;
     }
 
-    .rewardx-filter {
-        width: 100%;
-        justify-content: space-between;
-        background: #f1f5f9;
-        padding: 0.75rem 1rem;
-        border-radius: 14px;
-    }
-
-    .rewardx-filter-text {
+    .rewardx-tab {
         flex: 1;
-        text-align: right;
-    }
-
-    .rewardx-card-meta {
-        grid-template-columns: 1fr 1fr;
     }
 
     .rewardx-ledger-head,
     .rewardx-ledger-row {
         grid-template-columns: 1fr;
-        gap: 0.35rem;
         text-align: left;
     }
 
-    .rewardx-ledger-head {
-        display: none;
-    }
-
-    .rewardx-ledger-row {
-        border-top: 1px solid #e2e8f0;
-    }
-
+    .rewardx-ledger-head span,
     .rewardx-ledger-row span {
         display: flex;
         justify-content: space-between;
-        gap: 1rem;
-        font-size: 0.95rem;
-        position: relative;
-        padding-left: 0;
+        border-bottom: 1px solid rgba(226, 232, 240, 0.6);
+        padding-bottom: 0.4rem;
     }
 
     .rewardx-ledger-row span::before {
         content: attr(data-title);
-        font-weight: 600;
-        color: #94a3b8;
-        margin-right: auto;
+        color: var(--rx-muted);
+        font-size: 0.8rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+    }
+
+    .rewardx-ledger-head span::before {
+        content: '';
+    }
+
+    .rewardx-ledger-head span {
+        border: none;
+        padding-bottom: 0;
     }
 }
-
-@media (max-width: 640px) {
-    .rewardx-hero {
-        padding: 1.75rem;
-    }
-
-    .rewardx-hero-summary {
-        max-width: 100%;
-    }
-
-    .rewardx-hero-stats {
-        grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
-    }
-}
-

--- a/includes/views/account-rewardx.php
+++ b/includes/views/account-rewardx.php
@@ -22,6 +22,7 @@ foreach ($all_rewards as $reward_item) {
     $stock           = (int) ($reward_item['stock'] ?? 0);
     $is_unlimited    = $stock === -1;
     $is_out_of_stock = !$is_unlimited && $stock <= 0;
+
     if ($is_out_of_stock) {
         $out_of_stock++;
         continue;
@@ -35,107 +36,147 @@ foreach ($all_rewards as $reward_item) {
 }
 ?>
 <div class="rewardx-account" data-current-points="<?php echo esc_attr($points); ?>">
-    <header class="rewardx-balance rewardx-hero">
-        <div class="rewardx-hero-summary">
-            <p class="rewardx-hero-label"><?php esc_html_e('Điểm của bạn', 'woo-rewardx-lite'); ?></p>
-            <p class="rewardx-points"><?php echo esc_html(number_format_i18n($points)); ?></p>
-            <p class="rewardx-hero-hint"><?php esc_html_e('Đổi thưởng nhanh chóng với bố cục rõ ràng, dễ nhìn và tập trung vào điều quan trọng nhất.', 'woo-rewardx-lite'); ?></p>
+    <section class="rewardx-overview">
+        <div class="rewardx-overview-header">
+            <span class="rewardx-eyebrow"><?php esc_html_e('Chào mừng bạn trở lại', 'woo-rewardx-lite'); ?></span>
+            <h2 class="rewardx-headline"><?php esc_html_e('Trung tâm điểm thưởng', 'woo-rewardx-lite'); ?></h2>
+            <p class="rewardx-description"><?php esc_html_e('Theo dõi điểm, chi tiêu và nhanh chóng chọn ưu đãi phù hợp với bạn.', 'woo-rewardx-lite'); ?></p>
         </div>
-        <?php if ($total_rewards > 0) : ?>
-            <ul class="rewardx-hero-stats" role="list">
-                <li>
-                    <span class="rewardx-stat-label"><?php esc_html_e('Tổng phần thưởng', 'woo-rewardx-lite'); ?></span>
-                    <strong class="rewardx-stat-value"><?php echo esc_html(number_format_i18n($total_rewards)); ?></strong>
-                </li>
-                <li>
-                    <span class="rewardx-stat-label"><?php esc_html_e('Khả dụng ngay', 'woo-rewardx-lite'); ?></span>
-                    <strong class="rewardx-stat-value rewardx-stat-value--success"><?php echo esc_html(number_format_i18n($available_rewards)); ?></strong>
-                </li>
-                <li>
-                    <span class="rewardx-stat-label"><?php esc_html_e('Chờ đủ điểm', 'woo-rewardx-lite'); ?></span>
-                    <strong class="rewardx-stat-value rewardx-stat-value--muted"><?php echo esc_html(number_format_i18n($locked_rewards)); ?></strong>
-                </li>
-                <li>
-                    <span class="rewardx-stat-label"><?php esc_html_e('Tạm hết', 'woo-rewardx-lite'); ?></span>
-                    <strong class="rewardx-stat-value rewardx-stat-value--alert"><?php echo esc_html(number_format_i18n($out_of_stock)); ?></strong>
-                </li>
-            </ul>
-        <?php endif; ?>
-    </header>
 
-    <?php if (!$has_physical && !$has_voucher) : ?>
-        <div class="rewardx-empty">
-            <h3><?php esc_html_e('Hiện chưa có phần thưởng nào khả dụng.', 'woo-rewardx-lite'); ?></h3>
-            <p><?php esc_html_e('Hãy quay lại sau hoặc tiếp tục tích điểm để nhận thêm ưu đãi hấp dẫn.', 'woo-rewardx-lite'); ?></p>
+        <div class="rewardx-overview-grid">
+            <article class="rewardx-overview-card rewardx-overview-card--balance">
+                <header>
+                    <span class="rewardx-overview-label"><?php esc_html_e('Điểm hiện có', 'woo-rewardx-lite'); ?></span>
+                </header>
+                <strong class="rewardx-overview-value rewardx-points"><?php echo esc_html(number_format_i18n($points)); ?></strong>
+                <p class="rewardx-overview-subtext"><?php esc_html_e('Sẵn sàng sử dụng để đổi các phần thưởng yêu thích.', 'woo-rewardx-lite'); ?></p>
+            </article>
+
+            <article class="rewardx-overview-card">
+                <header>
+                    <span class="rewardx-overview-label"><?php esc_html_e('Tổng giá trị mua hàng', 'woo-rewardx-lite'); ?></span>
+                </header>
+                <strong class="rewardx-overview-value">
+                    <?php echo wp_kses_post(function_exists('wc_price') ? wc_price($total_spent) : number_format_i18n($total_spent, 0)); ?>
+                </strong>
+                <p class="rewardx-overview-subtext">
+                    <?php
+                    printf(
+                        /* translators: %s: number of orders */
+                        esc_html__('Đã hoàn tất %s đơn hàng.', 'woo-rewardx-lite'),
+                        esc_html(number_format_i18n($order_count))
+                    );
+                    ?>
+                </p>
+            </article>
+
+            <article class="rewardx-overview-card">
+                <header>
+                    <span class="rewardx-overview-label"><?php esc_html_e('Phần thưởng có thể đổi ngay', 'woo-rewardx-lite'); ?></span>
+                </header>
+                <strong class="rewardx-overview-value"><?php echo esc_html(number_format_i18n($available_rewards)); ?></strong>
+                <p class="rewardx-overview-subtext">
+                    <?php
+                    if ($available_rewards > 0) {
+                        esc_html_e('Hãy đổi thưởng để tận hưởng ưu đãi dành riêng cho bạn.', 'woo-rewardx-lite');
+                    } elseif ($locked_rewards > 0) {
+                        esc_html_e('Tiếp tục mua sắm để mở khóa thêm nhiều phần thưởng.', 'woo-rewardx-lite');
+                    } else {
+                        esc_html_e('Các phần thưởng mới sẽ được cập nhật thường xuyên.', 'woo-rewardx-lite');
+                    }
+                    ?>
+                </p>
+            </article>
         </div>
-    <?php endif; ?>
+    </section>
 
-    <?php if ($has_physical || $has_voucher) : ?>
-        <div class="rewardx-toolbar">
-            <?php if ($has_physical && $has_voucher) : ?>
-                <div class="rewardx-tabs" role="tablist" aria-label="<?php esc_attr_e('Danh mục phần thưởng', 'woo-rewardx-lite'); ?>">
-                    <button type="button" id="rewardx-tab-physical" class="rewardx-tab<?php echo $default_tab === 'physical' ? ' is-active' : ''; ?>" role="tab" aria-selected="<?php echo $default_tab === 'physical' ? 'true' : 'false'; ?>" aria-controls="rewardx-section-physical" data-target="physical">
-                        <?php esc_html_e('Quà vật lý', 'woo-rewardx-lite'); ?>
-                    </button>
-                    <button type="button" id="rewardx-tab-voucher" class="rewardx-tab<?php echo $default_tab === 'voucher' ? ' is-active' : ''; ?>" role="tab" aria-selected="<?php echo $default_tab === 'voucher' ? 'true' : 'false'; ?>" aria-controls="rewardx-section-voucher" data-target="voucher">
-                        <?php esc_html_e('Voucher', 'woo-rewardx-lite'); ?>
-                    </button>
-                </div>
-            <?php else : ?>
-                <div class="rewardx-tabs rewardx-tabs--single">
-                    <span class="rewardx-tab is-active" aria-current="true">
-                        <?php echo esc_html($has_physical ? __('Quà vật lý', 'woo-rewardx-lite') : __('Voucher', 'woo-rewardx-lite')); ?>
-                    </span>
+    <section class="rewardx-section rewardx-section--redeem">
+        <div class="rewardx-section-header">
+            <div>
+                <h3><?php esc_html_e('Đổi thưởng', 'woo-rewardx-lite'); ?></h3>
+                <p><?php esc_html_e('Chọn phần thưởng phù hợp với số điểm hiện có và xác nhận chỉ trong một bước.', 'woo-rewardx-lite'); ?></p>
+            </div>
+            <?php if ($has_physical || $has_voucher) : ?>
+                <div class="rewardx-toolbar">
+                    <?php if ($has_physical && $has_voucher) : ?>
+                        <div class="rewardx-tabs" role="tablist" aria-label="<?php esc_attr_e('Danh mục phần thưởng', 'woo-rewardx-lite'); ?>">
+                            <button type="button" id="rewardx-tab-physical" class="rewardx-tab<?php echo $default_tab === 'physical' ? ' is-active' : ''; ?>" role="tab" aria-selected="<?php echo $default_tab === 'physical' ? 'true' : 'false'; ?>" aria-controls="rewardx-section-physical" data-target="physical">
+                                <?php esc_html_e('Quà vật lý', 'woo-rewardx-lite'); ?>
+                            </button>
+                            <button type="button" id="rewardx-tab-voucher" class="rewardx-tab<?php echo $default_tab === 'voucher' ? ' is-active' : ''; ?>" role="tab" aria-selected="<?php echo $default_tab === 'voucher' ? 'true' : 'false'; ?>" aria-controls="rewardx-section-voucher" data-target="voucher">
+                                <?php esc_html_e('Voucher', 'woo-rewardx-lite'); ?>
+                            </button>
+                        </div>
+                    <?php else : ?>
+                        <div class="rewardx-tabs rewardx-tabs--single">
+                            <span class="rewardx-tab is-active" aria-current="true">
+                                <?php echo esc_html($has_physical ? __('Quà vật lý', 'woo-rewardx-lite') : __('Voucher', 'woo-rewardx-lite')); ?>
+                            </span>
+                        </div>
+                    <?php endif; ?>
+
+                    <label for="rewardx-filter-available" class="rewardx-filter">
+                        <input type="checkbox" id="rewardx-filter-available" class="rewardx-filter-toggle" />
+                        <span class="rewardx-filter-switch" aria-hidden="true">
+                            <span class="rewardx-filter-knob"></span>
+                        </span>
+                        <span class="rewardx-filter-text"><?php esc_html_e('Chỉ hiển thị phần thưởng đủ điểm', 'woo-rewardx-lite'); ?></span>
+                    </label>
                 </div>
             <?php endif; ?>
-
-            <label for="rewardx-filter-available" class="rewardx-filter">
-                <input type="checkbox" id="rewardx-filter-available" class="rewardx-filter-toggle" />
-                <span class="rewardx-filter-switch" aria-hidden="true">
-                    <span class="rewardx-filter-knob"></span>
-                </span>
-                <span class="rewardx-filter-text"><?php esc_html_e('Chỉ hiển thị phần thưởng đủ điểm', 'woo-rewardx-lite'); ?></span>
-            </label>
         </div>
-    <?php endif; ?>
 
-    <?php if ($has_physical) : ?>
-        <section id="rewardx-section-physical" class="rewardx-section<?php echo $default_tab !== 'physical' && $has_voucher ? ' rewardx-section--hidden' : ''; ?>" data-section="physical" role="<?php echo esc_attr($physical_role); ?>"<?php echo $physical_tab_id ? ' aria-labelledby="' . esc_attr($physical_tab_id) . '"' : ''; ?><?php echo $default_tab !== 'physical' && $has_voucher ? ' hidden' : ''; ?>>
-            <div class="rewardx-section-header">
-                <div>
-                    <h3><?php esc_html_e('Quà vật lý', 'woo-rewardx-lite'); ?></h3>
-                    <p><?php esc_html_e('Những sản phẩm hiện vật nổi bật được chọn lọc cho bạn.', 'woo-rewardx-lite'); ?></p>
-                </div>
+        <?php if (!$has_physical && !$has_voucher) : ?>
+            <div class="rewardx-empty">
+                <h4><?php esc_html_e('Hiện chưa có phần thưởng nào khả dụng.', 'woo-rewardx-lite'); ?></h4>
+                <p><?php esc_html_e('Hãy quay lại sau hoặc tiếp tục tích điểm để nhận thêm ưu đãi hấp dẫn.', 'woo-rewardx-lite'); ?></p>
             </div>
-            <div class="rewardx-grid">
-                <?php foreach ($physical_rewards as $item) : ?>
-                    <?php
-                    $stock            = (int) $item['stock'];
-                    $is_unlimited     = $stock === -1;
-                    $is_out_of_stock  = !$is_unlimited && $stock <= 0;
-                    $has_enough_point = $points >= (int) $item['cost'];
-                    $is_disabled      = $is_out_of_stock || !$has_enough_point;
-                    $status         = $is_out_of_stock ? 'out_of_stock' : ($has_enough_point ? 'available' : 'missing_points');
-                    $has_points_tag = $has_enough_point ? 'yes' : 'no';
-                    ?>
-                    <article class="rewardx-card" data-reward-id="<?php echo esc_attr($item['id']); ?>" data-type="physical" data-cost="<?php echo esc_attr($item['cost']); ?>" data-state="<?php echo esc_attr($status); ?>" data-has-points="<?php echo esc_attr($has_points_tag); ?>">
-                        <div class="rewardx-card-media<?php echo empty($item['thumbnail']) ? ' rewardx-card-media--empty' : ''; ?>">
-                            <?php if (!empty($item['thumbnail'])) : ?>
-                                <img src="<?php echo esc_url($item['thumbnail']); ?>" alt="<?php echo esc_attr($item['title']); ?>" />
-                            <?php endif; ?>
-                            <span class="rewardx-badge rewardx-badge-physical"><?php esc_html_e('Vật lý', 'woo-rewardx-lite'); ?></span>
-                        </div>
-                        <div class="rewardx-card-body">
-                            <h4 class="rewardx-card-title"><?php echo esc_html($item['title']); ?></h4>
-                            <p class="rewardx-card-description"><?php echo esc_html($item['excerpt']); ?></p>
-                            <dl class="rewardx-card-meta">
+        <?php endif; ?>
+
+        <?php if ($has_physical) : ?>
+            <section id="rewardx-section-physical" class="rewardx-section-body<?php echo $default_tab !== 'physical' && $has_voucher ? ' rewardx-section--hidden' : ''; ?>" data-section="physical" role="<?php echo esc_attr($physical_role); ?>"<?php echo $physical_tab_id ? ' aria-labelledby="' . esc_attr($physical_tab_id) . '"' : ''; ?><?php echo $default_tab !== 'physical' && $has_voucher ? ' hidden' : ''; ?>>
+                <header class="rewardx-subsection-header">
+                    <h4><?php esc_html_e('Quà vật lý', 'woo-rewardx-lite'); ?></h4>
+                    <p><?php esc_html_e('Những sản phẩm hiện vật nổi bật đang chờ bạn mang về.', 'woo-rewardx-lite'); ?></p>
+                </header>
+
+                <div class="rewardx-grid">
+                    <?php foreach ($physical_rewards as $item) : ?>
+                        <?php
+                        $stock            = (int) $item['stock'];
+                        $is_unlimited     = $stock === -1;
+                        $is_out_of_stock  = !$is_unlimited && $stock <= 0;
+                        $has_enough_point = $points >= (int) $item['cost'];
+                        $is_disabled      = $is_out_of_stock || !$has_enough_point;
+                        $status           = $is_out_of_stock ? 'out_of_stock' : ($has_enough_point ? 'available' : 'missing_points');
+                        $has_points_tag   = $has_enough_point ? 'yes' : 'no';
+                        ?>
+                        <article class="rewardx-card" data-reward-id="<?php echo esc_attr($item['id']); ?>" data-type="physical" data-cost="<?php echo esc_attr($item['cost']); ?>" data-state="<?php echo esc_attr($status); ?>" data-has-points="<?php echo esc_attr($has_points_tag); ?>">
+                            <div class="rewardx-card-top">
+                                <div class="rewardx-card-media<?php echo empty($item['thumbnail']) ? ' rewardx-card-media--empty' : ''; ?>">
+                                    <?php if (!empty($item['thumbnail'])) : ?>
+                                        <img src="<?php echo esc_url($item['thumbnail']); ?>" alt="<?php echo esc_attr($item['title']); ?>" />
+                                    <?php else : ?>
+                                        <span aria-hidden="true">📦</span>
+                                    <?php endif; ?>
+                                </div>
+                                <div class="rewardx-card-headline">
+                                    <h5 class="rewardx-card-title"><?php echo esc_html($item['title']); ?></h5>
+                                    <?php if (!empty($item['excerpt'])) : ?>
+                                        <p class="rewardx-card-description"><?php echo esc_html($item['excerpt']); ?></p>
+                                    <?php endif; ?>
+                                </div>
+                                <span class="rewardx-badge rewardx-badge-physical"><?php esc_html_e('Vật lý', 'woo-rewardx-lite'); ?></span>
+                            </div>
+
+                            <div class="rewardx-card-meta">
                                 <div class="rewardx-card-meta-item">
-                                    <dt><?php esc_html_e('Chi phí', 'woo-rewardx-lite'); ?></dt>
-                                    <dd><?php echo esc_html(number_format_i18n($item['cost'])); ?></dd>
+                                    <span class="rewardx-card-meta-label"><?php esc_html_e('Chi phí', 'woo-rewardx-lite'); ?></span>
+                                    <span class="rewardx-card-meta-value"><?php echo esc_html(number_format_i18n($item['cost'])); ?></span>
                                 </div>
                                 <div class="rewardx-card-meta-item">
-                                    <dt><?php esc_html_e('Tồn kho', 'woo-rewardx-lite'); ?></dt>
-                                    <dd>
+                                    <span class="rewardx-card-meta-label"><?php esc_html_e('Tồn kho', 'woo-rewardx-lite'); ?></span>
+                                    <span class="rewardx-card-meta-value">
                                         <?php if ($is_unlimited) : ?>
                                             <span class="rewardx-chip rewardx-chip--soft"><?php esc_html_e('Không giới hạn', 'woo-rewardx-lite'); ?></span>
                                         <?php elseif ($is_out_of_stock) : ?>
@@ -143,83 +184,80 @@ foreach ($all_rewards as $reward_item) {
                                         <?php else : ?>
                                             <span class="rewardx-chip"><?php echo esc_html(number_format_i18n($stock)); ?></span>
                                         <?php endif; ?>
-                                    </dd>
+                                    </span>
                                 </div>
-                            </dl>
-                        </div>
-                        <div class="rewardx-card-footer">
-                            <button class="button rewardx-redeem" data-action="physical" <?php disabled($is_disabled); ?>>
-                                <?php esc_html_e('Đổi quà', 'woo-rewardx-lite'); ?>
-                            </button>
-                            <?php if ($is_disabled && !$is_out_of_stock) : ?>
-                                <div class="rewardx-card-progress" aria-live="polite">
-                                    <span class="rewardx-card-progress-label"><?php esc_html_e('Còn thiếu', 'woo-rewardx-lite'); ?></span>
-                                    <strong class="rewardx-card-progress-value"><?php echo esc_html(number_format_i18n(max(0, (int) $item['cost'] - $points))); ?></strong>
-                                    <span class="rewardx-card-progress-suffix"><?php esc_html_e('điểm', 'woo-rewardx-lite'); ?></span>
-                                </div>
-                                <span class="rewardx-card-note"><?php esc_html_e('Bạn cần thêm điểm để đổi quà này.', 'woo-rewardx-lite'); ?></span>
-                            <?php elseif ($is_out_of_stock) : ?>
-                                <span class="rewardx-card-note rewardx-card-note--danger"><?php esc_html_e('Phần thưởng tạm thời đã hết.', 'woo-rewardx-lite'); ?></span>
-                            <?php else : ?>
-                                <span class="rewardx-card-note rewardx-card-note--success"><?php esc_html_e('Bạn đã đủ điểm để đổi quà ngay.', 'woo-rewardx-lite'); ?></span>
-                            <?php endif; ?>
-                        </div>
-                    </article>
-                <?php endforeach; ?>
-            </div>
-            <p class="rewardx-empty-filter" aria-live="polite" hidden>
-                <?php esc_html_e('Không tìm thấy phần thưởng phù hợp với bộ lọc hiện tại.', 'woo-rewardx-lite'); ?>
-            </p>
-        </section>
-    <?php endif; ?>
+                            </div>
 
-    <?php if ($has_voucher) : ?>
-        <section id="rewardx-section-voucher" class="rewardx-section<?php echo $default_tab !== 'voucher' && $has_physical ? ' rewardx-section--hidden' : ''; ?>" data-section="voucher" role="<?php echo esc_attr($voucher_role); ?>"<?php echo $voucher_tab_id ? ' aria-labelledby="' . esc_attr($voucher_tab_id) . '"' : ''; ?><?php echo $default_tab !== 'voucher' && $has_physical ? ' hidden' : ''; ?>>
-            <div class="rewardx-section-header">
-                <div>
-                    <h3><?php esc_html_e('Voucher', 'woo-rewardx-lite'); ?></h3>
+                            <div class="rewardx-card-footer">
+                                <button class="button rewardx-redeem" data-action="physical" <?php disabled($is_disabled); ?>>
+                                    <?php esc_html_e('Đổi quà', 'woo-rewardx-lite'); ?>
+                                </button>
+                                <?php if ($is_disabled && !$is_out_of_stock) : ?>
+                                    <div class="rewardx-card-progress" aria-live="polite">
+                                        <span class="rewardx-card-progress-label"><?php esc_html_e('Còn thiếu', 'woo-rewardx-lite'); ?></span>
+                                        <strong class="rewardx-card-progress-value"><?php echo esc_html(number_format_i18n(max(0, (int) $item['cost'] - $points))); ?></strong>
+                                        <span class="rewardx-card-progress-suffix"><?php esc_html_e('điểm', 'woo-rewardx-lite'); ?></span>
+                                    </div>
+                                    <span class="rewardx-card-note"><?php esc_html_e('Bạn cần thêm điểm để đổi quà này.', 'woo-rewardx-lite'); ?></span>
+                                <?php elseif ($is_out_of_stock) : ?>
+                                    <span class="rewardx-card-note rewardx-card-note--danger"><?php esc_html_e('Phần thưởng tạm thời đã hết.', 'woo-rewardx-lite'); ?></span>
+                                <?php else : ?>
+                                    <span class="rewardx-card-note rewardx-card-note--success"><?php esc_html_e('Bạn đã đủ điểm để đổi quà ngay.', 'woo-rewardx-lite'); ?></span>
+                                <?php endif; ?>
+                            </div>
+                        </article>
+                    <?php endforeach; ?>
+                </div>
+                <p class="rewardx-empty-filter" aria-live="polite" hidden>
+                    <?php esc_html_e('Không tìm thấy phần thưởng phù hợp với bộ lọc hiện tại.', 'woo-rewardx-lite'); ?>
+                </p>
+            </section>
+        <?php endif; ?>
+
+        <?php if ($has_voucher) : ?>
+            <section id="rewardx-section-voucher" class="rewardx-section-body<?php echo $default_tab !== 'voucher' && $has_physical ? ' rewardx-section--hidden' : ''; ?>" data-section="voucher" role="<?php echo esc_attr($voucher_role); ?>"<?php echo $voucher_tab_id ? ' aria-labelledby="' . esc_attr($voucher_tab_id) . '"' : ''; ?><?php echo $default_tab !== 'voucher' && $has_physical ? ' hidden' : ''; ?>>
+                <header class="rewardx-subsection-header">
+                    <h4><?php esc_html_e('Voucher', 'woo-rewardx-lite'); ?></h4>
                     <p><?php esc_html_e('Tiết kiệm nhiều hơn với voucher giảm giá dành riêng cho bạn.', 'woo-rewardx-lite'); ?></p>
-                </div>
-            </div>
-            <div class="rewardx-customer-insights">
-                <div>
-                    <span class="rewardx-insight-label"><?php esc_html_e('Tổng giá trị đơn hàng đã mua', 'woo-rewardx-lite'); ?></span>
-                    <strong class="rewardx-insight-value"><?php echo wp_kses_post(function_exists('wc_price') ? wc_price($total_spent) : number_format_i18n($total_spent, 2)); ?></strong>
-                </div>
-                <div>
-                    <span class="rewardx-insight-label"><?php esc_html_e('Số đơn hàng đã hoàn tất', 'woo-rewardx-lite'); ?></span>
-                    <strong class="rewardx-insight-value"><?php echo esc_html(number_format_i18n($order_count)); ?></strong>
-                </div>
-            </div>
-            <div class="rewardx-grid">
-                <?php foreach ($voucher_rewards as $item) : ?>
-                    <?php
-                    $stock            = (int) $item['stock'];
-                    $is_unlimited     = $stock === -1;
-                    $is_out_of_stock  = !$is_unlimited && $stock <= 0;
-                    $has_enough_point = $points >= (int) $item['cost'];
-                    $is_disabled      = $is_out_of_stock || !$has_enough_point;
-                    $status         = $is_out_of_stock ? 'out_of_stock' : ($has_enough_point ? 'available' : 'missing_points');
-                    $has_points_tag = $has_enough_point ? 'yes' : 'no';
-                    ?>
-                    <article class="rewardx-card" data-reward-id="<?php echo esc_attr($item['id']); ?>" data-type="voucher" data-cost="<?php echo esc_attr($item['cost']); ?>" data-state="<?php echo esc_attr($status); ?>" data-has-points="<?php echo esc_attr($has_points_tag); ?>">
-                        <div class="rewardx-card-media<?php echo empty($item['thumbnail']) ? ' rewardx-card-media--empty' : ''; ?>">
-                            <?php if (!empty($item['thumbnail'])) : ?>
-                                <img src="<?php echo esc_url($item['thumbnail']); ?>" alt="<?php echo esc_attr($item['title']); ?>" />
-                            <?php endif; ?>
-                            <span class="rewardx-badge rewardx-badge-voucher"><?php esc_html_e('Voucher', 'woo-rewardx-lite'); ?></span>
-                        </div>
-                        <div class="rewardx-card-body">
-                            <h4 class="rewardx-card-title"><?php echo esc_html($item['title']); ?></h4>
-                            <p class="rewardx-card-description"><?php echo esc_html($item['excerpt']); ?></p>
-                            <dl class="rewardx-card-meta">
+                </header>
+
+                <div class="rewardx-grid">
+                    <?php foreach ($voucher_rewards as $item) : ?>
+                        <?php
+                        $stock            = (int) $item['stock'];
+                        $is_unlimited     = $stock === -1;
+                        $is_out_of_stock  = !$is_unlimited && $stock <= 0;
+                        $has_enough_point = $points >= (int) $item['cost'];
+                        $is_disabled      = $is_out_of_stock || !$has_enough_point;
+                        $status           = $is_out_of_stock ? 'out_of_stock' : ($has_enough_point ? 'available' : 'missing_points');
+                        $has_points_tag   = $has_enough_point ? 'yes' : 'no';
+                        ?>
+                        <article class="rewardx-card" data-reward-id="<?php echo esc_attr($item['id']); ?>" data-type="voucher" data-cost="<?php echo esc_attr($item['cost']); ?>" data-state="<?php echo esc_attr($status); ?>" data-has-points="<?php echo esc_attr($has_points_tag); ?>">
+                            <div class="rewardx-card-top">
+                                <div class="rewardx-card-media<?php echo empty($item['thumbnail']) ? ' rewardx-card-media--empty' : ''; ?>">
+                                    <?php if (!empty($item['thumbnail'])) : ?>
+                                        <img src="<?php echo esc_url($item['thumbnail']); ?>" alt="<?php echo esc_attr($item['title']); ?>" />
+                                    <?php else : ?>
+                                        <span aria-hidden="true">🎟️</span>
+                                    <?php endif; ?>
+                                </div>
+                                <div class="rewardx-card-headline">
+                                    <h5 class="rewardx-card-title"><?php echo esc_html($item['title']); ?></h5>
+                                    <?php if (!empty($item['excerpt'])) : ?>
+                                        <p class="rewardx-card-description"><?php echo esc_html($item['excerpt']); ?></p>
+                                    <?php endif; ?>
+                                </div>
+                                <span class="rewardx-badge rewardx-badge-voucher"><?php esc_html_e('Voucher', 'woo-rewardx-lite'); ?></span>
+                            </div>
+
+                            <div class="rewardx-card-meta">
                                 <div class="rewardx-card-meta-item">
-                                    <dt><?php esc_html_e('Chi phí', 'woo-rewardx-lite'); ?></dt>
-                                    <dd><?php echo esc_html(number_format_i18n($item['cost'])); ?></dd>
+                                    <span class="rewardx-card-meta-label"><?php esc_html_e('Chi phí', 'woo-rewardx-lite'); ?></span>
+                                    <span class="rewardx-card-meta-value"><?php echo esc_html(number_format_i18n($item['cost'])); ?></span>
                                 </div>
                                 <div class="rewardx-card-meta-item">
-                                    <dt><?php esc_html_e('Số lượng', 'woo-rewardx-lite'); ?></dt>
-                                    <dd>
+                                    <span class="rewardx-card-meta-label"><?php esc_html_e('Số lượng', 'woo-rewardx-lite'); ?></span>
+                                    <span class="rewardx-card-meta-value">
                                         <?php if ($is_unlimited) : ?>
                                             <span class="rewardx-chip rewardx-chip--soft"><?php esc_html_e('Không giới hạn', 'woo-rewardx-lite'); ?></span>
                                         <?php elseif ($is_out_of_stock) : ?>
@@ -227,43 +265,44 @@ foreach ($all_rewards as $reward_item) {
                                         <?php else : ?>
                                             <span class="rewardx-chip"><?php echo esc_html(number_format_i18n($stock)); ?></span>
                                         <?php endif; ?>
-                                    </dd>
+                                    </span>
                                 </div>
-                                <?php if ($item['amount'] > 0) : ?>
+                                <?php if (!empty($item['amount'])) : ?>
                                     <div class="rewardx-card-meta-item">
-                                        <dt><?php esc_html_e('Trị giá', 'woo-rewardx-lite'); ?></dt>
-                                        <dd class="rewardx-card-highlight"><?php echo wp_kses_post(function_exists('wc_price') ? wc_price($item['amount']) : number_format_i18n($item['amount'], 0)); ?></dd>
+                                        <span class="rewardx-card-meta-label"><?php esc_html_e('Trị giá', 'woo-rewardx-lite'); ?></span>
+                                        <span class="rewardx-card-meta-value rewardx-card-highlight"><?php echo wp_kses_post(function_exists('wc_price') ? wc_price($item['amount']) : number_format_i18n($item['amount'], 0)); ?></span>
                                     </div>
                                 <?php endif; ?>
-                            </dl>
-                        </div>
-                        <div class="rewardx-card-footer">
-                            <button class="button rewardx-redeem" data-action="voucher" <?php disabled($is_disabled); ?>>
-                                <?php esc_html_e('Đổi voucher', 'woo-rewardx-lite'); ?>
-                            </button>
-                            <?php if ($is_disabled && !$is_out_of_stock) : ?>
-                                <div class="rewardx-card-progress" aria-live="polite">
-                                    <span class="rewardx-card-progress-label"><?php esc_html_e('Còn thiếu', 'woo-rewardx-lite'); ?></span>
-                                    <strong class="rewardx-card-progress-value"><?php echo esc_html(number_format_i18n(max(0, (int) $item['cost'] - $points))); ?></strong>
-                                    <span class="rewardx-card-progress-suffix"><?php esc_html_e('điểm', 'woo-rewardx-lite'); ?></span>
-                                </div>
-                                <span class="rewardx-card-note"><?php esc_html_e('Bạn chưa đủ điểm để đổi voucher này.', 'woo-rewardx-lite'); ?></span>
-                            <?php elseif ($is_out_of_stock) : ?>
-                                <span class="rewardx-card-note rewardx-card-note--danger"><?php esc_html_e('Voucher đã được đổi hết.', 'woo-rewardx-lite'); ?></span>
-                            <?php else : ?>
-                                <span class="rewardx-card-note rewardx-card-note--success"><?php esc_html_e('Voucher sẵn sàng để bạn đổi.', 'woo-rewardx-lite'); ?></span>
-                            <?php endif; ?>
-                        </div>
-                    </article>
-                <?php endforeach; ?>
-            </div>
-            <p class="rewardx-empty-filter" aria-live="polite" hidden>
-                <?php esc_html_e('Không tìm thấy phần thưởng phù hợp với bộ lọc hiện tại.', 'woo-rewardx-lite'); ?>
-            </p>
-        </section>
-    <?php endif; ?>
+                            </div>
 
-    <section class="rewardx-section">
+                            <div class="rewardx-card-footer">
+                                <button class="button rewardx-redeem" data-action="voucher" <?php disabled($is_disabled); ?>>
+                                    <?php esc_html_e('Đổi voucher', 'woo-rewardx-lite'); ?>
+                                </button>
+                                <?php if ($is_disabled && !$is_out_of_stock) : ?>
+                                    <div class="rewardx-card-progress" aria-live="polite">
+                                        <span class="rewardx-card-progress-label"><?php esc_html_e('Còn thiếu', 'woo-rewardx-lite'); ?></span>
+                                        <strong class="rewardx-card-progress-value"><?php echo esc_html(number_format_i18n(max(0, (int) $item['cost'] - $points))); ?></strong>
+                                        <span class="rewardx-card-progress-suffix"><?php esc_html_e('điểm', 'woo-rewardx-lite'); ?></span>
+                                    </div>
+                                    <span class="rewardx-card-note"><?php esc_html_e('Bạn chưa đủ điểm để đổi voucher này.', 'woo-rewardx-lite'); ?></span>
+                                <?php elseif ($is_out_of_stock) : ?>
+                                    <span class="rewardx-card-note rewardx-card-note--danger"><?php esc_html_e('Voucher đã được đổi hết.', 'woo-rewardx-lite'); ?></span>
+                                <?php else : ?>
+                                    <span class="rewardx-card-note rewardx-card-note--success"><?php esc_html_e('Voucher sẵn sàng để bạn đổi.', 'woo-rewardx-lite'); ?></span>
+                                <?php endif; ?>
+                            </div>
+                        </article>
+                    <?php endforeach; ?>
+                </div>
+                <p class="rewardx-empty-filter" aria-live="polite" hidden>
+                    <?php esc_html_e('Không tìm thấy phần thưởng phù hợp với bộ lọc hiện tại.', 'woo-rewardx-lite'); ?>
+                </p>
+            </section>
+        <?php endif; ?>
+    </section>
+
+    <section class="rewardx-section rewardx-section--history">
         <div class="rewardx-section-header">
             <div>
                 <h3><?php esc_html_e('Lịch sử giao dịch gần đây', 'woo-rewardx-lite'); ?></h3>


### PR DESCRIPTION
## Summary
- rebuild the customer loyalty account view with a modern overview of points, total spend, and reward availability
- redesign reward redemption sections with refreshed cards, tabs, and empty states for a cleaner experience
- update the front-end styles to match the new layout and improve responsiveness across breakpoints

## Testing
- php -l includes/views/account-rewardx.php

------
https://chatgpt.com/codex/tasks/task_e_68d902d47e88832b92a6bb952a5fc841