### PR TITLE
feat: làm mới giao diện trung tâm điểm thưởng

### DIFF
--- a/assets/css/rewardx.css
+++ b/assets/css/rewardx.css
@@ -18,6 +18,30 @@
     border-radius: 32px;
     box-shadow: 0 45px 80px rgba(15, 23, 42, 0.12);
     backdrop-filter: blur(16px);
+    position: relative;
+    overflow: hidden;
+    isolation: isolate;
+}
+
+.rewardx-account::before,
+.rewardx-account::after {
+    content: '';
+    position: absolute;
+    inset: -40% auto auto -30%;
+    width: 420px;
+    height: 420px;
+    background: radial-gradient(circle at center, rgba(37, 99, 235, 0.18), transparent 70%);
+    opacity: 0.7;
+    z-index: -1;
+    transform: translate3d(0, 0, 0);
+    animation: rewardx-float 12s ease-in-out infinite;
+}
+
+.rewardx-account::after {
+    inset: auto -35% -40% auto;
+    background: radial-gradient(circle at center, rgba(16, 185, 129, 0.22), transparent 70%);
+    animation-duration: 16s;
+    animation-delay: 1.2s;
 }
 
 .rewardx-account * {
@@ -72,7 +96,7 @@
     display: grid;
     gap: 0.75rem;
     overflow: hidden;
-    transition: transform 0.25s ease, box-shadow 0.25s ease;
+    transition: transform 0.25s ease, box-shadow 0.25s ease, border 0.25s ease;
 }
 
 .rewardx-overview-card::after {
@@ -85,8 +109,9 @@
 }
 
 .rewardx-overview-card:hover {
-    transform: translateY(-4px);
+    transform: translateY(-6px);
     box-shadow: 0 40px 70px rgba(15, 23, 42, 0.12);
+    border-color: rgba(37, 99, 235, 0.35);
 }
 
 .rewardx-overview-card:hover::after {
@@ -164,6 +189,23 @@
     padding: 0.75rem 1rem;
     box-shadow: var(--rx-shadow);
     flex-wrap: wrap;
+    position: relative;
+    overflow: hidden;
+}
+
+.rewardx-toolbar::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(120deg, rgba(37, 99, 235, 0.12), rgba(14, 165, 233, 0.05));
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    pointer-events: none;
+}
+
+.rewardx-toolbar:focus-within::after,
+.rewardx-toolbar:hover::after {
+    opacity: 1;
 }
 
 .rewardx-tabs {
@@ -195,6 +237,19 @@
     font-size: 0.95rem;
     cursor: pointer;
     transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+    position: relative;
+    isolation: isolate;
+}
+
+.rewardx-tab::after {
+    content: '';
+    position: absolute;
+    inset: 4px;
+    border-radius: inherit;
+    background: linear-gradient(135deg, rgba(37, 99, 235, 0.1), rgba(14, 165, 233, 0.08));
+    opacity: 0;
+    transition: opacity 0.2s ease;
+    z-index: -1;
 }
 
 .rewardx-tabs--single .rewardx-tab {
@@ -207,6 +262,10 @@
     color: var(--rx-accent);
     box-shadow: 0 12px 24px rgba(37, 99, 235, 0.25);
     transform: translateY(-1px);
+}
+
+.rewardx-tab.is-active::after {
+    opacity: 1;
 }
 
 .rewardx-tab:focus-visible {
@@ -312,12 +371,34 @@
     background: #ffffff;
     border: 1px solid rgba(226, 232, 240, 0.8);
     box-shadow: 0 25px 60px rgba(15, 23, 42, 0.07);
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, border 0.2s ease;
+    position: relative;
+    overflow: hidden;
+}
+
+.rewardx-card::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg, rgba(37, 99, 235, 0.12), transparent 65%);
+    opacity: 0;
+    transition: opacity 0.2s ease;
+    pointer-events: none;
+}
+
+.rewardx-card > * {
+    position: relative;
+    z-index: 1;
 }
 
 .rewardx-card:hover {
-    transform: translateY(-6px);
-    box-shadow: 0 35px 70px rgba(15, 23, 42, 0.12);
+    transform: translateY(-8px);
+    box-shadow: 0 35px 70px rgba(15, 23, 42, 0.14);
+    border-color: rgba(37, 99, 235, 0.35);
+}
+
+.rewardx-card:hover::before {
+    opacity: 1;
 }
 
 .rewardx-card-top {
@@ -336,6 +417,7 @@
     place-items: center;
     overflow: hidden;
     font-size: 1.75rem;
+    box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.25);
 }
 
 .rewardx-card-media img {
@@ -351,6 +433,7 @@
 .rewardx-card-headline {
     display: grid;
     gap: 0.45rem;
+    align-content: flex-start;
 }
 
 .rewardx-card-title {
@@ -375,6 +458,7 @@
     letter-spacing: 0.08em;
     background: rgba(59, 130, 246, 0.12);
     color: #1d4ed8;
+    box-shadow: inset 0 0 0 1px rgba(59, 130, 246, 0.18);
 }
 
 .rewardx-badge-physical {
@@ -391,6 +475,9 @@
     display: grid;
     gap: 0.85rem;
     grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    padding: 1rem;
+    border-radius: 16px;
+    background: rgba(248, 250, 252, 0.75);
 }
 
 .rewardx-card-meta-item {
@@ -414,6 +501,7 @@
 
 .rewardx-card-highlight {
     color: var(--rx-accent);
+    font-weight: 700;
 }
 
 .rewardx-chip {
@@ -426,6 +514,7 @@
     font-size: 0.85rem;
     font-weight: 600;
     color: var(--rx-ink);
+    box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.2);
 }
 
 .rewardx-chip--soft {
@@ -458,11 +547,12 @@
     font-weight: 600;
     cursor: pointer;
     transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+    box-shadow: 0 12px 28px rgba(37, 99, 235, 0.35);
 }
 
 .rewardx-redeem:hover:not(:disabled) {
     transform: translateY(-2px);
-    box-shadow: 0 18px 36px rgba(37, 99, 235, 0.3);
+    box-shadow: 0 22px 38px rgba(37, 99, 235, 0.38);
     background: #1d4ed8;
 }
 
@@ -512,10 +602,11 @@
 
 .rewardx-empty {
     text-align: center;
-    background: rgba(226, 232, 240, 0.5);
-    border-radius: 20px;
+    background: rgba(226, 232, 240, 0.45);
+    border-radius: 24px;
     padding: 2.5rem 2rem;
     border: 1px dashed rgba(148, 163, 184, 0.6);
+    box-shadow: inset 0 0 30px rgba(15, 23, 42, 0.04);
 }
 
 .rewardx-empty h4 {
@@ -547,6 +638,21 @@
     border: 1px solid rgba(226, 232, 240, 0.8);
     overflow: hidden;
     box-shadow: 0 25px 55px rgba(15, 23, 42, 0.08);
+    position: relative;
+}
+
+.rewardx-ledger::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(120deg, rgba(37, 99, 235, 0.08), transparent 65%);
+    opacity: 0.7;
+    pointer-events: none;
+}
+
+.rewardx-ledger > * {
+    position: relative;
+    z-index: 1;
 }
 
 .rewardx-ledger-head,
@@ -653,6 +759,34 @@
 .rewardx-toast.show {
     opacity: 1;
     transform: translateY(0);
+}
+
+@keyframes rewardx-float {
+    0%,
+    100% {
+        transform: translate3d(0, 0, 0) scale(1);
+    }
+
+    50% {
+        transform: translate3d(12px, -18px, 0) scale(1.05);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .rewardx-account,
+    .rewardx-account::before,
+    .rewardx-account::after,
+    .rewardx-card,
+    .rewardx-overview-card,
+    .rewardx-toolbar,
+    .rewardx-tab,
+    .rewardx-redeem {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        transition-delay: 0ms !important;
+        animation-name: none !important;
+    }
 }
 
 @media (max-width: 900px) {


### PR DESCRIPTION
## Summary
- làm mới giao diện trung tâm điểm thưởng với nền gradient và hiệu ứng nổi bật
- bổ sung trạng thái hover rõ ràng cho thẻ tổng quan, bộ lọc và danh sách phần thưởng
- tăng tính truy cập bằng hiệu ứng nhẹ và hỗ trợ giảm chuyển động khi người dùng yêu cầu

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d905debe70832b988cb34d069d759d