### PR TITLE
Revamp reward center layout and filters

### DIFF
--- a/assets/css/rewardx.css
+++ b/assets/css/rewardx.css
@@ -133,6 +133,10 @@
     color: #1d4ed8;
 }
 
+.rewardx-overview-value--accent {
+    color: var(--rx-positive);
+}
+
 .rewardx-overview-label {
     font-size: 0.85rem;
     letter-spacing: 0.1em;
@@ -206,6 +210,14 @@
 .rewardx-toolbar:focus-within::after,
 .rewardx-toolbar:hover::after {
     opacity: 1;
+}
+
+.rewardx-toolbar-actions {
+    display: inline-flex;
+    align-items: center;
+    gap: 1rem;
+    margin-left: auto;
+    flex-wrap: wrap;
 }
 
 .rewardx-tabs {
@@ -327,6 +339,42 @@
 
 .rewardx-filter-text {
     color: var(--rx-muted);
+}
+
+.rewardx-search {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    background: rgba(241, 245, 249, 0.6);
+    border: 1px solid rgba(203, 213, 225, 0.6);
+    transition: border 0.2s ease, background 0.2s ease;
+}
+
+.rewardx-search:focus-within {
+    border-color: rgba(37, 99, 235, 0.45);
+    background: rgba(255, 255, 255, 0.95);
+}
+
+.rewardx-search-input {
+    border: none;
+    background: transparent;
+    padding: 0.35rem 0.25rem;
+    font-size: 0.95rem;
+    min-width: 200px;
+    outline: none;
+    color: var(--rx-ink);
+}
+
+.rewardx-search-input::placeholder {
+    color: var(--rx-muted);
+}
+
+.rewardx-search-icon {
+    font-size: 1rem;
+    opacity: 0.65;
 }
 
 .rewardx-section-body {
@@ -813,6 +861,19 @@
         justify-content: space-between;
     }
 
+    .rewardx-toolbar-actions {
+        flex: 1 1 100%;
+        justify-content: space-between;
+    }
+
+    .rewardx-search {
+        flex: 1 1 auto;
+    }
+
+    .rewardx-search-input {
+        width: 100%;
+    }
+
     .rewardx-ledger-head,
     .rewardx-ledger-row {
         grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -836,9 +897,24 @@
         align-items: stretch;
     }
 
+    .rewardx-toolbar-actions {
+        width: 100%;
+        flex-direction: column;
+        align-items: stretch;
+    }
+
     .rewardx-filter {
         justify-content: space-between;
         width: 100%;
+    }
+
+    .rewardx-search {
+        width: 100%;
+        justify-content: space-between;
+    }
+
+    .rewardx-search-input {
+        min-width: 0;
     }
 
     .rewardx-tabs {

--- a/includes/views/account-rewardx.php
+++ b/includes/views/account-rewardx.php
@@ -60,6 +60,30 @@ foreach ($all_rewards as $reward_item) {
                     <?php echo wp_kses_post(function_exists('wc_price') ? wc_price($total_spent) : number_format_i18n($total_spent, 0)); ?>
                 </strong>
             </article>
+
+            <article class="rewardx-overview-card">
+                <header>
+                    <span class="rewardx-overview-label"><?php esc_html_e('Phần thưởng khả dụng', 'woo-rewardx-lite'); ?></span>
+                </header>
+                <strong class="rewardx-overview-value rewardx-overview-value--accent rewardx-stat-available"><?php echo esc_html(number_format_i18n($available_rewards)); ?></strong>
+                <p class="rewardx-overview-subtext"><?php esc_html_e('Bạn có thể đổi ngay lập tức.', 'woo-rewardx-lite'); ?></p>
+            </article>
+
+            <article class="rewardx-overview-card">
+                <header>
+                    <span class="rewardx-overview-label"><?php esc_html_e('Cần thêm điểm', 'woo-rewardx-lite'); ?></span>
+                </header>
+                <strong class="rewardx-overview-value rewardx-stat-locked"><?php echo esc_html(number_format_i18n($locked_rewards)); ?></strong>
+                <p class="rewardx-overview-subtext"><?php esc_html_e('Phần thưởng sẽ mở khóa khi tích đủ điểm.', 'woo-rewardx-lite'); ?></p>
+            </article>
+
+            <article class="rewardx-overview-card">
+                <header>
+                    <span class="rewardx-overview-label"><?php esc_html_e('Tạm hết hàng', 'woo-rewardx-lite'); ?></span>
+                </header>
+                <strong class="rewardx-overview-value rewardx-stat-oos"><?php echo esc_html(number_format_i18n($out_of_stock)); ?></strong>
+                <p class="rewardx-overview-subtext"><?php esc_html_e('Chúng tôi sẽ bổ sung trong thời gian sớm nhất.', 'woo-rewardx-lite'); ?></p>
+            </article>
         </div>
     </section>
 
@@ -83,6 +107,22 @@ foreach ($all_rewards as $reward_item) {
                             </span>
                         </div>
                     <?php endif; ?>
+
+                    <div class="rewardx-toolbar-actions">
+                        <label class="rewardx-search" for="rewardx-search">
+                            <span class="screen-reader-text"><?php esc_html_e('Tìm kiếm phần thưởng', 'woo-rewardx-lite'); ?></span>
+                            <input type="search" id="rewardx-search" class="rewardx-search-input" placeholder="<?php esc_attr_e('Tìm kiếm theo tên hoặc mô tả...', 'woo-rewardx-lite'); ?>" autocomplete="off" />
+                            <span class="rewardx-search-icon" aria-hidden="true">🔍</span>
+                        </label>
+
+                        <label class="rewardx-filter">
+                            <input type="checkbox" class="rewardx-filter-toggle" />
+                            <span class="rewardx-filter-switch" aria-hidden="true">
+                                <span class="rewardx-filter-knob"></span>
+                            </span>
+                            <span class="rewardx-filter-text"><?php esc_html_e('Chỉ hiện phần thưởng đổi được', 'woo-rewardx-lite'); ?></span>
+                        </label>
+                    </div>
                 </div>
             </div>
         <?php endif; ?>


### PR DESCRIPTION
## Summary
- expand the reward center overview with additional metrics and refreshed card styling
- add search and availability filters to the reward toolbar with responsive layout improvements
- update the frontend script to support live filtering and real-time metric updates

## Testing
- php -l includes/views/account-rewardx.php

------
https://chatgpt.com/codex/tasks/task_e_68d90f969e58832b84da45b9779e11e2