### PR TITLE
Shrink reward account summary and cards

### DIFF
--- a/assets/css/rewardx.css
+++ b/assets/css/rewardx.css
@@ -9,15 +9,15 @@
     --rx-accent-soft: rgba(37, 99, 235, 0.08);
     --rx-positive: #059669;
     --rx-danger: #dc2626;
-    --rx-shadow: 0 30px 60px rgba(15, 23, 42, 0.08);
-    max-width: 1120px;
+    --rx-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+    max-width: 960px;
     margin: 0 auto;
-    padding: 3rem 1.5rem 4rem;
+    padding: 2.25rem 1.5rem 3rem;
     color: var(--rx-ink);
-    background: linear-gradient(180deg, rgba(241, 245, 249, 0.9), rgba(255, 255, 255, 0.9));
-    border-radius: 32px;
-    box-shadow: 0 45px 80px rgba(15, 23, 42, 0.12);
-    backdrop-filter: blur(16px);
+    background: linear-gradient(180deg, rgba(241, 245, 249, 0.85), rgba(255, 255, 255, 0.9));
+    border-radius: 24px;
+    box-shadow: 0 24px 55px rgba(15, 23, 42, 0.1);
+    backdrop-filter: blur(12px);
     position: relative;
     overflow: hidden;
     isolation: isolate;
@@ -27,19 +27,19 @@
 .rewardx-account::after {
     content: '';
     position: absolute;
-    inset: -40% auto auto -30%;
-    width: 420px;
-    height: 420px;
-    background: radial-gradient(circle at center, rgba(37, 99, 235, 0.18), transparent 70%);
-    opacity: 0.7;
+    inset: -45% auto auto -35%;
+    width: 360px;
+    height: 360px;
+    background: radial-gradient(circle at center, rgba(37, 99, 235, 0.14), transparent 70%);
+    opacity: 0.6;
     z-index: -1;
     transform: translate3d(0, 0, 0);
     animation: rewardx-float 12s ease-in-out infinite;
 }
 
 .rewardx-account::after {
-    inset: auto -35% -40% auto;
-    background: radial-gradient(circle at center, rgba(16, 185, 129, 0.22), transparent 70%);
+    inset: auto -30% -45% auto;
+    background: radial-gradient(circle at center, rgba(16, 185, 129, 0.18), transparent 70%);
     animation-duration: 16s;
     animation-delay: 1.2s;
 }
@@ -48,10 +48,48 @@
     box-sizing: border-box;
 }
 
-.rewardx-overview {
+.rewardx-overview { 
     display: grid;
     gap: 2.5rem;
     margin-bottom: 3rem;
+}
+
+.rewardx-summary {
+    margin: 1.5rem 0 2.25rem;
+}
+
+.rewardx-summary-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.rewardx-summary-list li {
+    flex: 1 1 220px;
+    padding: 0.75rem 1rem;
+    border-radius: 14px;
+    background: rgba(255, 255, 255, 0.95);
+    border: 1px solid rgba(226, 232, 240, 0.9);
+    box-shadow: 0 6px 18px rgba(15, 23, 42, 0.08);
+}
+
+.rewardx-summary-label {
+    display: block;
+    font-size: 0.85rem;
+    color: var(--rx-muted);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    margin-bottom: 0.25rem;
+}
+
+.rewardx-summary-value {
+    font-size: 1.35rem;
+    font-weight: 600;
+    margin: 0;
+    color: var(--rx-ink);
 }
 
 .rewardx-overview-header {
@@ -413,12 +451,12 @@
 
 .rewardx-card {
     display: grid;
-    gap: 1.25rem;
-    padding: 1.6rem;
-    border-radius: 20px;
+    gap: 0.9rem;
+    padding: 1.15rem 1.25rem;
+    border-radius: 16px;
     background: #ffffff;
     border: 1px solid rgba(226, 232, 240, 0.8);
-    box-shadow: 0 25px 60px rgba(15, 23, 42, 0.07);
+    box-shadow: 0 16px 36px rgba(15, 23, 42, 0.08);
     transition: transform 0.2s ease, box-shadow 0.2s ease, border 0.2s ease;
     position: relative;
     overflow: hidden;
@@ -440,9 +478,9 @@
 }
 
 .rewardx-card:hover {
-    transform: translateY(-8px);
-    box-shadow: 0 35px 70px rgba(15, 23, 42, 0.14);
-    border-color: rgba(37, 99, 235, 0.35);
+    transform: translateY(-4px);
+    box-shadow: 0 22px 48px rgba(15, 23, 42, 0.12);
+    border-color: rgba(37, 99, 235, 0.3);
 }
 
 .rewardx-card:hover::before {
@@ -486,15 +524,15 @@
 
 .rewardx-card-title {
     margin: 0;
-    font-size: 1.1rem;
+    font-size: 1rem;
     font-weight: 600;
 }
 
 .rewardx-card-description {
     margin: 0;
     color: var(--rx-muted);
-    line-height: 1.5;
-    font-size: 0.95rem;
+    line-height: 1.45;
+    font-size: 0.9rem;
 }
 
 .rewardx-badge {

--- a/assets/js/rewardx-frontend.js
+++ b/assets/js/rewardx-frontend.js
@@ -58,42 +58,6 @@
         });
     }
 
-    function updateSummaryCounters() {
-        if (!$account.length) {
-            return;
-        }
-
-        var currentBalance = getCurrentBalance();
-        var counts = {
-            available: 0,
-            locked: 0,
-            oos: 0
-        };
-
-        $account.find('.rewardx-card').each(function () {
-            var $card = $(this);
-            var cost = parseInt($card.data('cost'), 10) || 0;
-            var state = $card.attr('data-state');
-            var isOutOfStock = state === 'out_of_stock';
-
-            if (isOutOfStock) {
-                counts.oos++;
-                return;
-            }
-
-            if (currentBalance >= cost) {
-                counts.available++;
-            } else {
-                counts.locked++;
-            }
-        });
-
-        var formatter = new Intl.NumberFormat();
-        $account.find('.rewardx-stat-available').text(formatter.format(counts.available));
-        $account.find('.rewardx-stat-locked').text(formatter.format(counts.locked));
-        $account.find('.rewardx-stat-oos').text(formatter.format(counts.oos));
-    }
-
     function applyRewardFilters() {
         if (!$account.length) {
             return;
@@ -102,7 +66,8 @@
         refreshCardStates();
 
         var showAvailableOnly = $account.find('.rewardx-filter-toggle').is(':checked');
-        var keyword = ($account.find('.rewardx-search-input').val() || '').toString().trim().toLowerCase();
+        var keywordField = $account.find('.rewardx-search-input');
+        var keyword = keywordField.length ? (keywordField.val() || '').toString().trim().toLowerCase() : '';
 
         $account.find('.rewardx-section[data-section]').each(function () {
             var $section = $(this);
@@ -135,7 +100,6 @@
             }
         });
 
-        updateSummaryCounters();
     }
 
     function activateTab(target) {
@@ -194,10 +158,6 @@
     });
 
     $account.on('change', '.rewardx-filter-toggle', function () {
-        applyRewardFilters();
-    });
-
-    $account.on('input', '.rewardx-search-input', function () {
         applyRewardFilters();
     });
 

--- a/includes/views/account-rewardx.php
+++ b/includes/views/account-rewardx.php
@@ -12,27 +12,6 @@ $physical_tab_id    = $has_physical && $has_voucher ? 'rewardx-tab-physical' : '
 $voucher_tab_id     = $has_physical && $has_voucher ? 'rewardx-tab-voucher' : '';
 $physical_role      = $has_physical && $has_voucher ? 'tabpanel' : 'region';
 $voucher_role       = $has_physical && $has_voucher ? 'tabpanel' : 'region';
-$all_rewards        = array_merge($physical_rewards, $voucher_rewards);
-$available_rewards  = 0;
-$locked_rewards     = 0;
-$out_of_stock       = 0;
-
-foreach ($all_rewards as $reward_item) {
-    $stock           = (int) ($reward_item['stock'] ?? 0);
-    $is_unlimited    = $stock === -1;
-    $is_out_of_stock = !$is_unlimited && $stock <= 0;
-
-    if ($is_out_of_stock) {
-        $out_of_stock++;
-        continue;
-    }
-
-    if ($points >= (int) ($reward_item['cost'] ?? 0)) {
-        $available_rewards++;
-    } else {
-        $locked_rewards++;
-    }
-}
 ?>
 <div class="rewardx-account" data-current-points="<?php echo esc_attr($points); ?>">
     <header class="rewardx-intro">
@@ -52,18 +31,6 @@ foreach ($all_rewards as $reward_item) {
                 <strong class="rewardx-summary-value">
                     <?php echo wp_kses_post(function_exists('wc_price') ? wc_price($total_spent) : number_format_i18n($total_spent, 0)); ?>
                 </strong>
-            </li>
-            <li>
-                <span class="rewardx-summary-label"><?php esc_html_e('Phần thưởng khả dụng', 'woo-rewardx-lite'); ?></span>
-                <strong class="rewardx-summary-value rewardx-stat-available"><?php echo esc_html(number_format_i18n($available_rewards)); ?></strong>
-            </li>
-            <li>
-                <span class="rewardx-summary-label"><?php esc_html_e('Cần thêm điểm', 'woo-rewardx-lite'); ?></span>
-                <strong class="rewardx-summary-value rewardx-stat-locked"><?php echo esc_html(number_format_i18n($locked_rewards)); ?></strong>
-            </li>
-            <li>
-                <span class="rewardx-summary-label"><?php esc_html_e('Tạm hết hàng', 'woo-rewardx-lite'); ?></span>
-                <strong class="rewardx-summary-value rewardx-stat-oos"><?php echo esc_html(number_format_i18n($out_of_stock)); ?></strong>
             </li>
         </ul>
     </section>
@@ -92,11 +59,6 @@ foreach ($all_rewards as $reward_item) {
                         </span>
                     </p>
                 <?php endif; ?>
-
-                <label class="rewardx-search" for="rewardx-search">
-                    <span class="screen-reader-text"><?php esc_html_e('Tìm kiếm phần thưởng', 'woo-rewardx-lite'); ?></span>
-                    <input type="search" id="rewardx-search" class="rewardx-search-input" placeholder="<?php esc_attr_e('Tìm kiếm theo tên hoặc mô tả...', 'woo-rewardx-lite'); ?>" autocomplete="off" />
-                </label>
 
                 <label class="rewardx-filter">
                     <input type="checkbox" class="rewardx-filter-toggle" />


### PR DESCRIPTION
## Summary
- simplify the account summary to focus on points and total spend and remove unused counters and the voucher search control
- tighten the reward card and container styling to reduce visual bulk across the loyalty account page
- update the frontend filtering script to reflect the streamlined layout without summary counters or search listeners

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d913fa9860832bab3d061c6f6650ee