### PR TITLE
Simplify rewards redemption layout and improve responsiveness

### DIFF
--- a/assets/css/rewardx.css
+++ b/assets/css/rewardx.css
@@ -420,6 +420,12 @@
     gap: 1.5rem;
 }
 
+.rewardx-card-grid {
+    display: grid;
+    gap: 1.25rem;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
 .rewardx-subsection-header {
     display: flex;
     align-items: baseline;
@@ -460,6 +466,7 @@
     transition: transform 0.2s ease, box-shadow 0.2s ease, border 0.2s ease;
     position: relative;
     overflow: hidden;
+    grid-template-rows: auto 1fr auto;
 }
 
 .rewardx-card::before {
@@ -557,21 +564,27 @@
     color: #db2777;
 }
 
+.rewardx-card-header {
+    display: grid;
+    gap: 0.5rem;
+}
+
 .rewardx-card-meta {
     display: grid;
-    gap: 0.85rem;
-    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
     padding: 1rem;
     border-radius: 16px;
     background: rgba(248, 250, 252, 0.75);
+    margin: 0;
 }
 
-.rewardx-card-meta-item {
+.rewardx-card-meta > div {
     display: grid;
     gap: 0.35rem;
 }
 
-.rewardx-card-meta-label {
+.rewardx-card-meta dt {
     font-size: 0.75rem;
     text-transform: uppercase;
     letter-spacing: 0.12em;
@@ -579,7 +592,8 @@
     font-weight: 600;
 }
 
-.rewardx-card-meta-value {
+.rewardx-card-meta dd {
+    margin: 0;
     font-size: 1rem;
     font-weight: 600;
     color: var(--rx-ink);
@@ -880,6 +894,10 @@
         padding: 2.5rem 1.25rem 3.5rem;
     }
 
+    .rewardx-card-grid {
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    }
+
     .rewardx-card-top {
         grid-template-columns: minmax(0, 1fr);
         justify-items: start;
@@ -927,6 +945,10 @@
 @media (max-width: 640px) {
     .rewardx-account {
         border-radius: 20px;
+    }
+
+    .rewardx-card-grid {
+        grid-template-columns: minmax(0, 1fr);
     }
 
     .rewardx-section-header,

--- a/includes/views/account-rewardx.php
+++ b/includes/views/account-rewardx.php
@@ -38,44 +38,20 @@ $voucher_role       = $has_physical && $has_voucher ? 'tabpanel' : 'region';
     <section class="rewardx-section rewardx-section--redeem">
         <header>
             <h3><?php esc_html_e('Phần thưởng có thể đổi', 'woo-rewardx-lite'); ?></h3>
-            <p><?php esc_html_e('Tìm phần thưởng bạn cần, lọc theo nhu cầu và đổi ngay khi đủ điểm.', 'woo-rewardx-lite'); ?></p>
         </header>
-
-        <?php if ($has_physical || $has_voucher) : ?>
-            <div class="rewardx-controls">
-                <?php if ($has_physical && $has_voucher) : ?>
-                    <div class="rewardx-tabs" role="tablist" aria-label="<?php esc_attr_e('Danh mục phần thưởng', 'woo-rewardx-lite'); ?>">
-                        <button type="button" id="rewardx-tab-physical" class="rewardx-tab<?php echo $default_tab === 'physical' ? ' is-active' : ''; ?>" role="tab" aria-selected="<?php echo $default_tab === 'physical' ? 'true' : 'false'; ?>" aria-controls="rewardx-section-physical" data-target="physical">
-                            <?php esc_html_e('Quà vật lý', 'woo-rewardx-lite'); ?>
-                        </button>
-                        <button type="button" id="rewardx-tab-voucher" class="rewardx-tab<?php echo $default_tab === 'voucher' ? ' is-active' : ''; ?>" role="tab" aria-selected="<?php echo $default_tab === 'voucher' ? 'true' : 'false'; ?>" aria-controls="rewardx-section-voucher" data-target="voucher">
-                            <?php esc_html_e('Voucher', 'woo-rewardx-lite'); ?>
-                        </button>
-                    </div>
-                <?php elseif ($has_physical || $has_voucher) : ?>
-                    <p class="rewardx-tabs">
-                        <span class="rewardx-tab is-active" aria-current="true">
-                            <?php echo esc_html($has_physical ? __('Quà vật lý', 'woo-rewardx-lite') : __('Voucher', 'woo-rewardx-lite')); ?>
-                        </span>
-                    </p>
-                <?php endif; ?>
-
-                <label class="rewardx-filter">
-                    <input type="checkbox" class="rewardx-filter-toggle" />
-                    <span><?php esc_html_e('Chỉ hiện phần thưởng đổi được', 'woo-rewardx-lite'); ?></span>
-                </label>
-            </div>
-        <?php endif; ?>
 
         <?php if (!$has_physical && !$has_voucher) : ?>
             <p><?php esc_html_e('Hiện chưa có phần thưởng nào khả dụng. Hãy quay lại sau hoặc tích thêm điểm.', 'woo-rewardx-lite'); ?></p>
         <?php endif; ?>
 
         <?php if ($has_physical) : ?>
-            <section id="rewardx-section-physical" class="rewardx-section-body<?php echo $default_tab !== 'physical' && $has_voucher ? ' rewardx-section--hidden' : ''; ?>" data-section="physical" role="<?php echo esc_attr($physical_role); ?>"<?php echo $physical_tab_id ? ' aria-labelledby="' . esc_attr($physical_tab_id) . '"' : ''; ?><?php echo $default_tab !== 'physical' && $has_voucher ? ' hidden' : ''; ?>>
-                <h4><?php esc_html_e('Quà vật lý', 'woo-rewardx-lite'); ?></h4>
-                <?php foreach ($physical_rewards as $item) : ?>
-                    <?php
+            <section id="rewardx-section-physical" class="rewardx-section-body" data-section="physical" role="<?php echo esc_attr($physical_role); ?>">
+                <header class="rewardx-subsection-header">
+                    <h4><?php esc_html_e('Quà vật lý', 'woo-rewardx-lite'); ?></h4>
+                </header>
+                <div class="rewardx-card-grid">
+                    <?php foreach ($physical_rewards as $item) : ?>
+                        <?php
                     $stock            = (int) $item['stock'];
                     $is_unlimited     = $stock === -1;
                     $is_out_of_stock  = !$is_unlimited && $stock <= 0;
@@ -84,38 +60,50 @@ $voucher_role       = $has_physical && $has_voucher ? 'tabpanel' : 'region';
                     $status           = $is_out_of_stock ? 'out_of_stock' : ($has_enough_point ? 'available' : 'missing_points');
                     $has_points_tag   = $has_enough_point ? 'yes' : 'no';
                     ?>
-                    <article class="rewardx-card" data-reward-id="<?php echo esc_attr($item['id']); ?>" data-type="physical" data-cost="<?php echo esc_attr($item['cost']); ?>" data-state="<?php echo esc_attr($status); ?>" data-has-points="<?php echo esc_attr($has_points_tag); ?>">
-                        <h5 class="rewardx-card-title"><?php echo esc_html($item['title']); ?></h5>
-                        <?php if (!empty($item['excerpt'])) : ?>
-                            <p class="rewardx-card-description"><?php echo esc_html($item['excerpt']); ?></p>
-                        <?php endif; ?>
-                        <p><strong><?php esc_html_e('Chi phí:', 'woo-rewardx-lite'); ?></strong> <?php echo esc_html(number_format_i18n($item['cost'])); ?></p>
-                        <p>
-                            <strong><?php esc_html_e('Tồn kho:', 'woo-rewardx-lite'); ?></strong>
-                            <?php if ($is_unlimited) : ?>
-                                <?php esc_html_e('Không giới hạn', 'woo-rewardx-lite'); ?>
-                            <?php elseif ($is_out_of_stock) : ?>
-                                <?php esc_html_e('Hết hàng', 'woo-rewardx-lite'); ?>
-                            <?php else : ?>
-                                <?php echo esc_html(number_format_i18n($stock)); ?>
-                            <?php endif; ?>
-                        </p>
-                        <button class="button rewardx-redeem" data-action="physical" <?php disabled($is_disabled); ?>>
-                            <?php esc_html_e('Đổi quà', 'woo-rewardx-lite'); ?>
-                        </button>
-                        <?php if ($is_disabled && !$is_out_of_stock) : ?>
-                            <p class="rewardx-card-note"><?php esc_html_e('Bạn cần thêm điểm để đổi quà này.', 'woo-rewardx-lite'); ?>
-                                (<?php esc_html_e('Còn thiếu', 'woo-rewardx-lite'); ?>
-                                <?php echo esc_html(number_format_i18n(max(0, (int) $item['cost'] - $points))); ?>
-                                <?php esc_html_e('điểm', 'woo-rewardx-lite'); ?>)
-                            </p>
-                        <?php elseif ($is_out_of_stock) : ?>
-                            <p class="rewardx-card-note"><?php esc_html_e('Phần thưởng tạm thời đã hết.', 'woo-rewardx-lite'); ?></p>
-                        <?php else : ?>
-                            <p class="rewardx-card-note"><?php esc_html_e('Bạn đã đủ điểm để đổi quà ngay.', 'woo-rewardx-lite'); ?></p>
-                        <?php endif; ?>
-                    </article>
-                <?php endforeach; ?>
+                        <article class="rewardx-card" data-reward-id="<?php echo esc_attr($item['id']); ?>" data-type="physical" data-cost="<?php echo esc_attr($item['cost']); ?>" data-state="<?php echo esc_attr($status); ?>" data-has-points="<?php echo esc_attr($has_points_tag); ?>">
+                            <header class="rewardx-card-header">
+                                <h5 class="rewardx-card-title"><?php echo esc_html($item['title']); ?></h5>
+                                <?php if (!empty($item['excerpt'])) : ?>
+                                    <p class="rewardx-card-description"><?php echo esc_html($item['excerpt']); ?></p>
+                                <?php endif; ?>
+                            </header>
+                            <dl class="rewardx-card-meta">
+                                <div>
+                                    <dt><?php esc_html_e('Chi phí', 'woo-rewardx-lite'); ?></dt>
+                                    <dd><?php echo esc_html(number_format_i18n($item['cost'])); ?></dd>
+                                </div>
+                                <div>
+                                    <dt><?php esc_html_e('Tồn kho', 'woo-rewardx-lite'); ?></dt>
+                                    <dd>
+                                        <?php if ($is_unlimited) : ?>
+                                            <?php esc_html_e('Không giới hạn', 'woo-rewardx-lite'); ?>
+                                        <?php elseif ($is_out_of_stock) : ?>
+                                            <?php esc_html_e('Hết hàng', 'woo-rewardx-lite'); ?>
+                                        <?php else : ?>
+                                            <?php echo esc_html(number_format_i18n($stock)); ?>
+                                        <?php endif; ?>
+                                    </dd>
+                                </div>
+                            </dl>
+                            <div class="rewardx-card-footer">
+                                <button class="button rewardx-redeem" data-action="physical" <?php disabled($is_disabled); ?>>
+                                    <?php esc_html_e('Đổi quà', 'woo-rewardx-lite'); ?>
+                                </button>
+                                <?php if ($is_disabled && !$is_out_of_stock) : ?>
+                                    <p class="rewardx-card-note"><?php esc_html_e('Bạn cần thêm điểm để đổi quà này.', 'woo-rewardx-lite'); ?>
+                                        (<?php esc_html_e('Còn thiếu', 'woo-rewardx-lite'); ?>
+                                        <?php echo esc_html(number_format_i18n(max(0, (int) $item['cost'] - $points))); ?>
+                                        <?php esc_html_e('điểm', 'woo-rewardx-lite'); ?>)
+                                    </p>
+                                <?php elseif ($is_out_of_stock) : ?>
+                                    <p class="rewardx-card-note"><?php esc_html_e('Phần thưởng tạm thời đã hết.', 'woo-rewardx-lite'); ?></p>
+                                <?php else : ?>
+                                    <p class="rewardx-card-note"><?php esc_html_e('Bạn đã đủ điểm để đổi quà ngay.', 'woo-rewardx-lite'); ?></p>
+                                <?php endif; ?>
+                            </div>
+                        </article>
+                    <?php endforeach; ?>
+                </div>
                 <p class="rewardx-empty-filter" aria-live="polite" hidden>
                     <?php esc_html_e('Không tìm thấy phần thưởng phù hợp với bộ lọc hiện tại.', 'woo-rewardx-lite'); ?>
                 </p>
@@ -123,10 +111,13 @@ $voucher_role       = $has_physical && $has_voucher ? 'tabpanel' : 'region';
         <?php endif; ?>
 
         <?php if ($has_voucher) : ?>
-            <section id="rewardx-section-voucher" class="rewardx-section-body<?php echo $default_tab !== 'voucher' && $has_physical ? ' rewardx-section--hidden' : ''; ?>" data-section="voucher" role="<?php echo esc_attr($voucher_role); ?>"<?php echo $voucher_tab_id ? ' aria-labelledby="' . esc_attr($voucher_tab_id) . '"' : ''; ?><?php echo $default_tab !== 'voucher' && $has_physical ? ' hidden' : ''; ?>>
-                <h4><?php esc_html_e('Voucher', 'woo-rewardx-lite'); ?></h4>
-                <?php foreach ($voucher_rewards as $item) : ?>
-                    <?php
+            <section id="rewardx-section-voucher" class="rewardx-section-body" data-section="voucher" role="<?php echo esc_attr($voucher_role); ?>">
+                <header class="rewardx-subsection-header">
+                    <h4><?php esc_html_e('Voucher', 'woo-rewardx-lite'); ?></h4>
+                </header>
+                <div class="rewardx-card-grid">
+                    <?php foreach ($voucher_rewards as $item) : ?>
+                        <?php
                     $stock            = (int) $item['stock'];
                     $is_unlimited     = $stock === -1;
                     $is_out_of_stock  = !$is_unlimited && $stock <= 0;
@@ -135,41 +126,56 @@ $voucher_role       = $has_physical && $has_voucher ? 'tabpanel' : 'region';
                     $status           = $is_out_of_stock ? 'out_of_stock' : ($has_enough_point ? 'available' : 'missing_points');
                     $has_points_tag   = $has_enough_point ? 'yes' : 'no';
                     ?>
-                    <article class="rewardx-card" data-reward-id="<?php echo esc_attr($item['id']); ?>" data-type="voucher" data-cost="<?php echo esc_attr($item['cost']); ?>" data-state="<?php echo esc_attr($status); ?>" data-has-points="<?php echo esc_attr($has_points_tag); ?>">
-                        <h5 class="rewardx-card-title"><?php echo esc_html($item['title']); ?></h5>
-                        <?php if (!empty($item['excerpt'])) : ?>
-                            <p class="rewardx-card-description"><?php echo esc_html($item['excerpt']); ?></p>
-                        <?php endif; ?>
-                        <p><strong><?php esc_html_e('Chi phí:', 'woo-rewardx-lite'); ?></strong> <?php echo esc_html(number_format_i18n($item['cost'])); ?></p>
-                        <p>
-                            <strong><?php esc_html_e('Số lượng:', 'woo-rewardx-lite'); ?></strong>
-                            <?php if ($is_unlimited) : ?>
-                                <?php esc_html_e('Không giới hạn', 'woo-rewardx-lite'); ?>
-                            <?php elseif ($is_out_of_stock) : ?>
-                                <?php esc_html_e('Đã hết', 'woo-rewardx-lite'); ?>
-                            <?php else : ?>
-                                <?php echo esc_html(number_format_i18n($stock)); ?>
-                            <?php endif; ?>
-                        </p>
-                        <?php if (!empty($item['amount'])) : ?>
-                            <p><strong><?php esc_html_e('Trị giá:', 'woo-rewardx-lite'); ?></strong> <?php echo wp_kses_post(function_exists('wc_price') ? wc_price($item['amount']) : number_format_i18n($item['amount'], 0)); ?></p>
-                        <?php endif; ?>
-                        <button class="button rewardx-redeem" data-action="voucher" <?php disabled($is_disabled); ?>>
-                            <?php esc_html_e('Đổi voucher', 'woo-rewardx-lite'); ?>
-                        </button>
-                        <?php if ($is_disabled && !$is_out_of_stock) : ?>
-                            <p class="rewardx-card-note"><?php esc_html_e('Bạn chưa đủ điểm để đổi voucher này.', 'woo-rewardx-lite'); ?>
-                                (<?php esc_html_e('Còn thiếu', 'woo-rewardx-lite'); ?>
-                                <?php echo esc_html(number_format_i18n(max(0, (int) $item['cost'] - $points))); ?>
-                                <?php esc_html_e('điểm', 'woo-rewardx-lite'); ?>)
-                            </p>
-                        <?php elseif ($is_out_of_stock) : ?>
-                            <p class="rewardx-card-note"><?php esc_html_e('Voucher đã được đổi hết.', 'woo-rewardx-lite'); ?></p>
-                        <?php else : ?>
-                            <p class="rewardx-card-note"><?php esc_html_e('Voucher sẵn sàng để bạn đổi.', 'woo-rewardx-lite'); ?></p>
-                        <?php endif; ?>
-                    </article>
-                <?php endforeach; ?>
+                        <article class="rewardx-card" data-reward-id="<?php echo esc_attr($item['id']); ?>" data-type="voucher" data-cost="<?php echo esc_attr($item['cost']); ?>" data-state="<?php echo esc_attr($status); ?>" data-has-points="<?php echo esc_attr($has_points_tag); ?>">
+                            <header class="rewardx-card-header">
+                                <h5 class="rewardx-card-title"><?php echo esc_html($item['title']); ?></h5>
+                                <?php if (!empty($item['excerpt'])) : ?>
+                                    <p class="rewardx-card-description"><?php echo esc_html($item['excerpt']); ?></p>
+                                <?php endif; ?>
+                            </header>
+                            <dl class="rewardx-card-meta">
+                                <div>
+                                    <dt><?php esc_html_e('Chi phí', 'woo-rewardx-lite'); ?></dt>
+                                    <dd><?php echo esc_html(number_format_i18n($item['cost'])); ?></dd>
+                                </div>
+                                <div>
+                                    <dt><?php esc_html_e('Số lượng', 'woo-rewardx-lite'); ?></dt>
+                                    <dd>
+                                        <?php if ($is_unlimited) : ?>
+                                            <?php esc_html_e('Không giới hạn', 'woo-rewardx-lite'); ?>
+                                        <?php elseif ($is_out_of_stock) : ?>
+                                            <?php esc_html_e('Đã hết', 'woo-rewardx-lite'); ?>
+                                        <?php else : ?>
+                                            <?php echo esc_html(number_format_i18n($stock)); ?>
+                                        <?php endif; ?>
+                                    </dd>
+                                </div>
+                                <?php if (!empty($item['amount'])) : ?>
+                                    <div>
+                                        <dt><?php esc_html_e('Trị giá', 'woo-rewardx-lite'); ?></dt>
+                                        <dd><?php echo wp_kses_post(function_exists('wc_price') ? wc_price($item['amount']) : number_format_i18n($item['amount'], 0)); ?></dd>
+                                    </div>
+                                <?php endif; ?>
+                            </dl>
+                            <div class="rewardx-card-footer">
+                                <button class="button rewardx-redeem" data-action="voucher" <?php disabled($is_disabled); ?>>
+                                    <?php esc_html_e('Đổi voucher', 'woo-rewardx-lite'); ?>
+                                </button>
+                                <?php if ($is_disabled && !$is_out_of_stock) : ?>
+                                    <p class="rewardx-card-note"><?php esc_html_e('Bạn chưa đủ điểm để đổi voucher này.', 'woo-rewardx-lite'); ?>
+                                        (<?php esc_html_e('Còn thiếu', 'woo-rewardx-lite'); ?>
+                                        <?php echo esc_html(number_format_i18n(max(0, (int) $item['cost'] - $points))); ?>
+                                        <?php esc_html_e('điểm', 'woo-rewardx-lite'); ?>)
+                                    </p>
+                                <?php elseif ($is_out_of_stock) : ?>
+                                    <p class="rewardx-card-note"><?php esc_html_e('Voucher đã được đổi hết.', 'woo-rewardx-lite'); ?></p>
+                                <?php else : ?>
+                                    <p class="rewardx-card-note"><?php esc_html_e('Voucher sẵn sàng để bạn đổi.', 'woo-rewardx-lite'); ?></p>
+                                <?php endif; ?>
+                            </div>
+                        </article>
+                    <?php endforeach; ?>
+                </div>
                 <p class="rewardx-empty-filter" aria-live="polite" hidden>
                     <?php esc_html_e('Không tìm thấy phần thưởng phù hợp với bộ lọc hiện tại.', 'woo-rewardx-lite'); ?>
                 </p>


### PR DESCRIPTION
## Summary
- remove the descriptive banner, tab switcher, and availability toggle from the rewards section
- restructure reward cards with semantic headers and metadata blocks grouped inside a responsive grid
- adjust frontend styles for cards to scale cleanly across desktop and mobile viewports

## Testing
- php -l includes/views/account-rewardx.php

------
https://chatgpt.com/codex/tasks/task_e_68d91615353c832ba32b0a02f6560ede