### PR TITLE
Điều chỉnh bố cục phần đổi thưởng

### DIFF
--- a/assets/css/rewardx.css
+++ b/assets/css/rewardx.css
@@ -198,8 +198,8 @@
 
 .rewardx-section {
     display: grid;
-    gap: 1.75rem;
-    margin-bottom: 3rem;
+    gap: 1.5rem;
+    margin-bottom: 2.5rem;
 }
 
 .rewardx-section-header {
@@ -422,8 +422,8 @@
 
 .rewardx-card-grid {
     display: grid;
-    gap: 1.25rem;
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1rem;
+    grid-template-columns: 1fr;
 }
 
 .rewardx-subsection-header {
@@ -457,8 +457,8 @@
 
 .rewardx-card {
     display: grid;
-    gap: 0.9rem;
-    padding: 1.15rem 1.25rem;
+    gap: 0.75rem;
+    padding: 1rem 1.15rem;
     border-radius: 16px;
     background: #ffffff;
     border: 1px solid rgba(226, 232, 240, 0.8);
@@ -467,6 +467,17 @@
     position: relative;
     overflow: hidden;
     grid-template-rows: auto 1fr auto;
+}
+
+@media (min-width: 1024px) {
+    .rewardx-card-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 1.25rem;
+    }
+
+    .rewardx-card {
+        padding: 1.2rem 1.5rem;
+    }
 }
 
 .rewardx-card::before {
@@ -894,10 +905,6 @@
         padding: 2.5rem 1.25rem 3.5rem;
     }
 
-    .rewardx-card-grid {
-        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    }
-
     .rewardx-card-top {
         grid-template-columns: minmax(0, 1fr);
         justify-items: start;
@@ -909,7 +916,7 @@
     }
 
     .rewardx-card {
-        padding: 1.4rem;
+        padding: 1.1rem 1.25rem;
     }
 
     .rewardx-toolbar {
@@ -945,10 +952,6 @@
 @media (max-width: 640px) {
     .rewardx-account {
         border-radius: 20px;
-    }
-
-    .rewardx-card-grid {
-        grid-template-columns: minmax(0, 1fr);
     }
 
     .rewardx-section-header,


### PR DESCRIPTION
## Summary
- thiết lập lưới phần thưởng hiển thị một cột mặc định và hai cột trên màn hình lớn để đáp ứng bố cục PC/mobile
- tinh chỉnh khoảng cách section cùng padding của thẻ phần thưởng nhằm gọn gàng hơn trên mọi kích thước

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d91833a610832bb0b96d4c7aa20e8e