### PR TITLE
Handle expired sessions during reward redemption

### DIFF
--- a/assets/js/rewardx-frontend.js
+++ b/assets/js/rewardx-frontend.js
@@ -188,6 +188,12 @@
             nonce: rewardxFrontend.nonce
         })
             .done(function (response) {
+                if (!response || typeof response !== 'object') {
+                    showToast(rewardxFrontend.i18n.sessionExpired);
+
+                    return;
+                }
+
                 if (response.success) {
                     updateBalance(response.data.balance);
 
@@ -199,11 +205,21 @@
 
                     showToast(response.data.message);
                 } else {
-                    showToast(response.data && response.data.message ? response.data.message : 'Error');
+                    var errorMessage = response.data && response.data.message ? response.data.message : rewardxFrontend.i18n.unknownError;
+                    showToast(errorMessage);
                 }
             })
             .fail(function (xhr) {
-                var message = xhr.responseJSON && xhr.responseJSON.data && xhr.responseJSON.data.message ? xhr.responseJSON.data.message : 'Error';
+                var message;
+
+                if (xhr && (xhr.status === 401 || xhr.status === 403 || xhr.responseText === '0')) {
+                    message = rewardxFrontend.i18n.sessionExpired;
+                } else if (xhr.responseJSON && xhr.responseJSON.data && xhr.responseJSON.data.message) {
+                    message = xhr.responseJSON.data.message;
+                } else {
+                    message = rewardxFrontend.i18n.unknownError;
+                }
+
                 showToast(message);
             })
             .always(function () {

--- a/includes/Frontend/class-frontend.php
+++ b/includes/Frontend/class-frontend.php
@@ -57,6 +57,8 @@ class Frontend
                 'expiry'         => __('Hết hạn', 'woo-rewardx-lite'),
                 'redeemVoucher'  => __('Đổi voucher', 'woo-rewardx-lite'),
                 'redeemPhysical' => __('Đổi quà', 'woo-rewardx-lite'),
+                'sessionExpired' => __('Phiên đăng nhập đã hết hạn. Vui lòng đăng nhập lại.', 'woo-rewardx-lite'),
+                'unknownError'   => __('Đã xảy ra lỗi không xác định. Vui lòng thử lại.', 'woo-rewardx-lite'),
             ],
         ]);
     }

--- a/includes/Redeem/class-redeem-handler.php
+++ b/includes/Redeem/class-redeem-handler.php
@@ -25,6 +25,8 @@ class Redeem_Handler
     {
         add_action('wp_ajax_rewardx_redeem_physical', [$this, 'redeem_physical']);
         add_action('wp_ajax_rewardx_redeem_voucher', [$this, 'redeem_voucher']);
+        add_action('wp_ajax_nopriv_rewardx_redeem_physical', [$this, 'redeem_physical']);
+        add_action('wp_ajax_nopriv_rewardx_redeem_voucher', [$this, 'redeem_voucher']);
     }
 
     public function redeem_physical(): void


### PR DESCRIPTION
## Summary
- allow the redeem AJAX endpoints to run for unauthenticated requests so they can return a proper JSON error
- expose new i18n strings and update the frontend script to surface clearer messages when the session is expired or an unknown error occurs

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d91dbe8c04832ba0494a211618c2f1