### PR TITLE
Handle coupon creation failures gracefully

### DIFF
--- a/includes/Redeem/class-redeem-handler.php
+++ b/includes/Redeem/class-redeem-handler.php
@@ -280,17 +280,24 @@ class Redeem_Handler
 
         $code = $this->generate_coupon_code($user_id);
 
-        $coupon = new \WC_Coupon();
-        $coupon->set_code($code);
-        $coupon->set_amount($amount);
-        $coupon->set_discount_type('fixed_cart');
-        $coupon->set_usage_limit(1);
-        $coupon->set_individual_use(true);
-        $coupon->set_email_restrictions([$user->user_email]);
+        try {
+            $coupon = new \WC_Coupon();
+            $coupon->set_code($code);
+            $coupon->set_amount($amount);
+            $coupon->set_discount_type('fixed_cart');
+            $coupon->set_usage_limit(1);
+            $coupon->set_individual_use(true);
+            $coupon->set_email_restrictions([$user->user_email]);
 
-        $expiry = gmdate('Y-m-d', strtotime('+' . $expiry_days . ' days'));
-        $coupon->set_date_expires(strtotime($expiry . ' 23:59:59'));
-        $coupon->save();
+            $expiry = gmdate('Y-m-d', strtotime('+' . $expiry_days . ' days'));
+            $coupon->set_date_expires(strtotime($expiry . ' 23:59:59'));
+            $coupon->save();
+        } catch (\Throwable $e) {
+            return new WP_Error(
+                'rewardx_coupon_error',
+                sprintf(__('Không thể tạo voucher: %s', 'woo-rewardx-lite'), $e->getMessage())
+            );
+        }
 
         return [
             'code'   => $code,


### PR DESCRIPTION
## Summary
- wrap voucher coupon creation in a try/catch block so WooCommerce exceptions return a readable WP_Error
- surface coupon creation failures to the AJAX caller instead of triggering a generic unknown error toast

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d921fb3e6c832bba5fa745c827c3ec