### PR TITLE
Fix missing email recipient in voucher template data

### DIFF
--- a/includes/Emails/class-email-voucher.php
+++ b/includes/Emails/class-email-voucher.php
@@ -42,6 +42,7 @@ class Voucher_Email extends \WC_Email
             'coupon_code'   => $data['code'] ?? '',
             'coupon_amount' => $data['amount'] ?? 0,
             'coupon_expiry' => $data['expiry'] ?? '',
+            'email'         => $this,
         ];
 
         $settings  = Plugin::instance()->get_settings()->get_settings();


### PR DESCRIPTION
## Summary
- include the email instance in voucher template data so WooCommerce templates can read the recipient safely

## Testing
- php -l includes/Emails/class-email-voucher.php

------
https://chatgpt.com/codex/tasks/task_e_68d924c994ec832bb71170467a150ea7