### PR TITLE
Fix voucher email templates to avoid protected data access

### DIFF
--- a/templates/emails/plain/rewardx-voucher.php
+++ b/templates/emails/plain/rewardx-voucher.php
@@ -7,9 +7,9 @@ if (!defined('ABSPATH')) {
 
 <?php esc_html_e('Cảm ơn bạn đã đổi thưởng trên cửa hàng của chúng tôi. Dưới đây là thông tin voucher:', 'woo-rewardx-lite'); ?>
 
-<?php esc_html_e('Mã voucher:', 'woo-rewardx-lite'); ?> <?php echo $email->data['coupon_code']; ?>
-<?php esc_html_e('Giá trị:', 'woo-rewardx-lite'); ?> <?php echo wp_strip_all_tags(wc_price($email->data['coupon_amount'])); ?>
-<?php esc_html_e('Hết hạn vào:', 'woo-rewardx-lite'); ?> <?php echo $email->data['coupon_expiry']; ?>
+<?php esc_html_e('Mã voucher:', 'woo-rewardx-lite'); ?> <?php echo $coupon_code; ?>
+<?php esc_html_e('Giá trị:', 'woo-rewardx-lite'); ?> <?php echo wp_strip_all_tags(wc_price($coupon_amount)); ?>
+<?php esc_html_e('Hết hạn vào:', 'woo-rewardx-lite'); ?> <?php echo $coupon_expiry; ?>
 
 <?php esc_html_e('Voucher chỉ sử dụng cho tài khoản email này và có hiệu lực một lần.', 'woo-rewardx-lite'); ?>
 

--- a/templates/emails/rewardx-voucher.php
+++ b/templates/emails/rewardx-voucher.php
@@ -12,15 +12,15 @@ if (!defined('ABSPATH')) {
 <table style="width:100%;border-collapse:collapse;">
     <tr>
         <th style="text-align:left;border:1px solid #ddd;padding:8px;"><?php esc_html_e('Mã voucher', 'woo-rewardx-lite'); ?></th>
-        <td style="border:1px solid #ddd;padding:8px;font-weight:bold;font-size:18px;"><?php echo esc_html($email->data['coupon_code']); ?></td>
+        <td style="border:1px solid #ddd;padding:8px;font-weight:bold;font-size:18px;"><?php echo esc_html($coupon_code); ?></td>
     </tr>
     <tr>
         <th style="text-align:left;border:1px solid #ddd;padding:8px;"><?php esc_html_e('Giá trị', 'woo-rewardx-lite'); ?></th>
-        <td style="border:1px solid #ddd;padding:8px;"><?php echo wp_kses_post(wc_price($email->data['coupon_amount'])); ?></td>
+        <td style="border:1px solid #ddd;padding:8px;"><?php echo wp_kses_post(wc_price($coupon_amount)); ?></td>
     </tr>
     <tr>
         <th style="text-align:left;border:1px solid #ddd;padding:8px;"><?php esc_html_e('Hết hạn vào', 'woo-rewardx-lite'); ?></th>
-        <td style="border:1px solid #ddd;padding:8px;"><?php echo esc_html($email->data['coupon_expiry']); ?></td>
+        <td style="border:1px solid #ddd;padding:8px;"><?php echo esc_html($coupon_expiry); ?></td>
     </tr>
 </table>
 


### PR DESCRIPTION
## Summary
- replace direct access to protected WC_Email data with template variables in voucher email templates
- ensure both HTML and plain templates read coupon details from extracted arguments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d95be7e410832ba07a0f2da99281c3