### PR TITLE
Align reward modal close button

### DIFF
--- a/assets/css/rewardx.css
+++ b/assets/css/rewardx.css
@@ -850,6 +850,10 @@
     border-radius: 50%;
     font-size: 1.25rem;
     cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 1;
 }
 
 .rewardx-toast {


### PR DESCRIPTION
## Summary
- center the reward modal close button to prevent misalignment when displaying the coupon form

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d95dd05260832b8641a2b03d679246