### PR TITLE
Register top customers shortcode on init

### DIFF
--- a/includes/Frontend/class-frontend.php
+++ b/includes/Frontend/class-frontend.php
@@ -24,8 +24,13 @@ class Frontend
         add_action('init', [$this, 'register_endpoint']);
         add_action('wp_enqueue_scripts', [$this, 'enqueue_assets']);
         add_action('wp_enqueue_scripts', [$this, 'register_shortcode_assets']);
+        add_action('init', [$this, 'register_shortcodes']);
         add_filter('woocommerce_account_menu_items', [$this, 'add_account_menu']);
         add_action('woocommerce_account_rewardx_endpoint', [$this, 'render_account_page']);
+    }
+
+    public function register_shortcodes(): void
+    {
         add_shortcode('rewardx_top_customers', [$this, 'render_top_customers_shortcode']);
     }
 


### PR DESCRIPTION
## Summary
- register the RewardX top customers shortcode during init so WordPress recognizes it reliably

## Testing
- php -l includes/Frontend/class-frontend.php

------
https://chatgpt.com/codex/tasks/task_e_68daa71ffe58832b9b9299b931d43fc8