### PR TITLE
Hiển thị trạng thái trống cho shortcode top khách hàng

### DIFF
--- a/assets/css/rewardx-top-customers.css
+++ b/assets/css/rewardx-top-customers.css
@@ -143,6 +143,20 @@
     color: var(--rewardx-text-dark);
 }
 
+.rewardx-top-customers--empty {
+    display: grid;
+    place-items: center;
+    min-height: clamp(160px, 35vw, 220px);
+    text-align: center;
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.1), rgba(10, 5, 42, 0.2));
+}
+
+.rewardx-top-customers__empty {
+    margin: 0;
+    font-size: clamp(0.95rem, 2.4vw, 1.1rem);
+    color: rgba(255, 255, 255, 0.85);
+}
+
 @media (max-width: 768px) {
     .rewardx-top-customers {
         border-radius: 24px;

--- a/includes/Frontend/class-frontend.php
+++ b/includes/Frontend/class-frontend.php
@@ -131,11 +131,18 @@ class Frontend
 
         $customers = $this->get_top_customers($limit);
 
-        if (empty($customers)) {
-            return '';
-        }
-
         wp_enqueue_style('rewardx-top-customers');
+
+        if (empty($customers)) {
+            ob_start();
+            ?>
+            <div class="rewardx-top-customers rewardx-top-customers--empty">
+                <p class="rewardx-top-customers__empty"><?php echo esc_html__('Hiện chưa có dữ liệu xếp hạng khách hàng.', 'woo-rewardx-lite'); ?></p>
+            </div>
+            <?php
+
+            return (string) ob_get_clean();
+        }
 
         ob_start();
         ?>


### PR DESCRIPTION
## Summary
- hiển thị khối thông báo thân thiện khi shortcode rewardx_top_customers không có dữ liệu
- bổ sung style cho trạng thái trống để giữ bố cục đẹp mắt

## Testing
- php -l includes/Frontend/class-frontend.php

------
https://chatgpt.com/codex/tasks/task_e_68daa931a300832baed77603140dd589