### PR TITLE
Ensure RewardX frontend hooks initialize for shortcode logging

### DIFF
--- a/includes/Frontend/class-frontend.php
+++ b/includes/Frontend/class-frontend.php
@@ -13,6 +13,7 @@ if (!defined('ABSPATH')) {
 class Frontend
 {
     private Points_Manager $points_manager;
+    private bool $hooks_registered = false;
 
     public function __construct(Points_Manager $points_manager)
     {
@@ -21,6 +22,12 @@ class Frontend
 
     public function hooks(): void
     {
+        if ($this->hooks_registered) {
+            return;
+        }
+
+        $this->hooks_registered = true;
+
         add_action('init', [$this, 'register_endpoint']);
         add_action('wp_enqueue_scripts', [$this, 'enqueue_assets']);
         add_action('wp_enqueue_scripts', [$this, 'register_shortcode_assets']);
@@ -32,6 +39,16 @@ class Frontend
     public function register_shortcodes(): void
     {
         add_shortcode('rewardx_top_customers', [$this, 'render_top_customers_shortcode']);
+
+        if (defined('REWARDX_DEBUG_SHORTCODES') && REWARDX_DEBUG_SHORTCODES) {
+            global $shortcode_tags;
+
+            if (isset($shortcode_tags['rewardx_top_customers'])) {
+                error_log('[RewardX] Shortcode rewardx_top_customers is registered');
+            } else {
+                error_log('[RewardX] Shortcode rewardx_top_customers is NOT registered');
+            }
+        }
     }
 
     public function register_endpoint(): void

--- a/includes/class-rewardx-plugin.php
+++ b/includes/class-rewardx-plugin.php
@@ -94,7 +94,6 @@ final class Plugin
         $this->settings->register();
         $this->reward_cpt->hooks();
         $this->transaction_cpt->hooks();
-        $this->frontend->hooks();
         $this->admin->hooks();
         $this->redeem_handler->hooks();
         $this->emails->hooks();
@@ -117,5 +116,10 @@ final class Plugin
     public function get_settings(): Settings
     {
         return $this->settings;
+    }
+
+    public function get_frontend(): Frontend
+    {
+        return $this->frontend;
     }
 }

--- a/woo-rewardx-lite.php
+++ b/woo-rewardx-lite.php
@@ -10,6 +10,8 @@ Requires at least: 6.0
 Requires PHP:      7.4
 */
 
+use RewardX\Plugin;
+
 if (!defined('ABSPATH')) {
     exit;
 }
@@ -74,5 +76,7 @@ add_action('plugins_loaded', static function (): void {
         return;
     }
 
-    RewardX\Plugin::instance()->boot();
+    $plugin = Plugin::instance();
+    $plugin->boot();
+    $plugin->get_frontend()->hooks();
 });


### PR DESCRIPTION
## Summary
- expose the frontend service from the plugin bootstrapper and guard repeated hook registration
- initialize the frontend hooks from the main plugin file so the shortcode debug log can run reliably

## Testing
- php -l includes/Frontend/class-frontend.php
- php -l includes/class-rewardx-plugin.php
- php -l woo-rewardx-lite.php

------
https://chatgpt.com/codex/tasks/task_e_68daab40fe70832bb1b149eda1735224