### PR TITLE
Fix top customers query to include guest spending

### DIFF
--- a/includes/Frontend/class-frontend.php
+++ b/includes/Frontend/class-frontend.php
@@ -258,7 +258,7 @@ class Frontend
         if ($table_exists === $table_name) {
             $results = $wpdb->get_results(
                 $wpdb->prepare(
-                    "SELECT user_id, first_name, last_name, email, city, total_spent FROM {$table_name} WHERE user_id > 0 ORDER BY total_spent DESC LIMIT %d",
+                    "SELECT customer_id, user_id, first_name, last_name, email, city, total_spent FROM {$table_name} WHERE total_spent > 0 ORDER BY total_spent DESC LIMIT %d",
                     $limit
                 ),
                 ARRAY_A
@@ -288,10 +288,15 @@ class Frontend
                     continue;
                 }
 
+                $total_spent = (float) $customer->get_total_spent();
+                if ($total_spent <= 0) {
+                    continue;
+                }
+
                 $customers[] = [
                     'name'        => $this->mask_customer_name((string) $customer->get_first_name(), (string) $customer->get_last_name(), (string) $customer->get_email()),
                     'meta'        => $this->format_customer_meta((string) $customer->get_billing_city()),
-                    'total_spent' => (float) $customer->get_total_spent(),
+                    'total_spent' => $total_spent,
                 ];
 
                 if (count($customers) >= $limit) {


### PR DESCRIPTION
## Summary
- include rows from the WooCommerce customer lookup table even when the customer has no associated user account
- filter fallback customer query results to skip anyone without recorded spending

## Testing
- php -l includes/Frontend/class-frontend.php

------
https://chatgpt.com/codex/tasks/task_e_68daadb9100c832bb8afa2f26073490a