### PR TITLE
Ensure leaderboard query uses prefixed statuses

### DIFF
--- a/includes/Frontend/class-frontend.php
+++ b/includes/Frontend/class-frontend.php
@@ -318,6 +318,19 @@ class Frontend
                  */
                 $statuses = apply_filters('rewardx_top_customers_order_statuses', array_values(array_filter($statuses)));
 
+                $statuses = array_values(array_filter(array_map(
+                    static function ($status) {
+                        $status = trim((string) $status);
+
+                        if ('' === $status) {
+                            return '';
+                        }
+
+                        return 0 === strpos($status, 'wc-') ? $status : 'wc-' . $status;
+                    },
+                    $statuses
+                )));
+
                 if (!empty($statuses)) {
                     $placeholders    = implode(',', array_fill(0, count($statuses), '%s'));
                     $prepared_values = array_merge($statuses, [$limit]);


### PR DESCRIPTION
## Summary
- normalize order statuses used by the top customers query to include the `wc-` prefix when missing
- prevent the leaderboard query from returning no rows when statuses are stored with a prefix

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dab34e8768832b8e160d77adbc4de8