### PR TITLE
Bổ sung fallback bảng xếp hạng khách hàng bằng điểm thưởng

### DIFF
--- a/assets/css/rewardx-top-customers.css
+++ b/assets/css/rewardx-top-customers.css
@@ -143,6 +143,10 @@
     color: var(--rewardx-text-dark);
 }
 
+.rewardx-top-customers__value--points {
+    font-variant-numeric: tabular-nums;
+}
+
 .rewardx-top-customers--empty {
     display: grid;
     place-items: center;


### PR DESCRIPTION
## Summary
- bổ sung logic leaderboard ưu tiên dữ liệu chi tiêu nhưng tự động lấy top khách hàng theo điểm thưởng khi WooCommerce chưa có thống kê
- hiển thị thông điệp và định dạng giá trị phù hợp với điểm thưởng, kèm tinh chỉnh nhỏ cho stylesheet
- bổ sung kiểm tra sự tồn tại của bảng/cột trước khi chạy truy vấn top khách hàng để tránh lỗi cơ sở dữ liệu trên các phiên bản WooCommerce cũ

## Testing
- php -l includes/Frontend/class-frontend.php

------
https://chatgpt.com/codex/tasks/task_e_68dabca484e8832bbe38e80c47598055