### PR TITLE
Filter leaderboard logs to spending metrics

### DIFF
--- a/includes/Frontend/class-frontend.php
+++ b/includes/Frontend/class-frontend.php
@@ -687,9 +687,18 @@ class Frontend
         }
 
         if (!empty($customers)) {
-            usort($customers, static function (array $a, array $b): int {
-                return $b['total_spent'] <=> $a['total_spent'];
-            });
+            $customers = array_values(array_filter(
+                $customers,
+                static function (array $customer): bool {
+                    return 'spending' === ($customer['metric'] ?? 'spending');
+                }
+            ));
+
+            if (!empty($customers)) {
+                usort($customers, static function (array $a, array $b): int {
+                    return $b['total_spent'] <=> $a['total_spent'];
+                });
+            }
         }
 
         if (is_array($all_customers)) {


### PR DESCRIPTION
## Summary
- filter leaderboard customer collection to only keep spending-based entries before sorting

## Testing
- php -l includes/Frontend/class-frontend.php

------
https://chatgpt.com/codex/tasks/task_e_68daca03e630832b98ab56e5c5662463