### PR TITLE
Ensure top customer leaderboard retains spending metric

### DIFF
--- a/includes/Frontend/class-frontend.php
+++ b/includes/Frontend/class-frontend.php
@@ -784,8 +784,12 @@ class Frontend
                 $customers[$key]['total_spent'] = $total_spent;
             }
 
-            if ('' !== $normalized_unique_key && (!isset($customers[$key]['metric']) || $metric !== $customers[$key]['metric'])) {
-                $customers[$key]['metric'] = $metric;
+            if ('' !== $normalized_unique_key) {
+                $current_metric = $customers[$key]['metric'] ?? '';
+
+                if ('spending' === $metric || '' === $current_metric) {
+                    $customers[$key]['metric'] = $metric;
+                }
             }
 
             if ('' !== $meta && '' === ($customers[$key]['meta'] ?? '')) {


### PR DESCRIPTION
## Summary
- prevent point-based fallback entries from overriding the spending metric when merging top-customer data

## Testing
- php -l includes/Frontend/class-frontend.php

------
https://chatgpt.com/codex/tasks/task_e_68dace9d1698832ba3ae6e2bf0f2778e