### PR TITLE
Improve ranking styles and remove unused logging

### DIFF
--- a/assets/css/rewardx-top-customers.css
+++ b/assets/css/rewardx-top-customers.css
@@ -1,105 +1,79 @@
 :root {
-    --rewardx-gradient-start: #654de4;
-    --rewardx-gradient-end: #9f6af7;
-    --rewardx-card-bg: rgba(255, 255, 255, 0.92);
-    --rewardx-card-border: rgba(255, 255, 255, 0.45);
-    --rewardx-text-dark: #1a1330;
-    --rewardx-text-muted: #4f4579;
-    --rewardx-highlight-gold: #f8d57e;
-    --rewardx-highlight-silver: #e5e7ef;
-    --rewardx-highlight-bronze: #f3c7a2;
+    --rewardx-surface: #ffffff;
+    --rewardx-surface-muted: #f5f6fb;
+    --rewardx-border: rgba(39, 36, 67, 0.12);
+    --rewardx-text-dark: #211a3d;
+    --rewardx-text-muted: #5a5674;
+    --rewardx-highlight-gold: linear-gradient(135deg, #f8d57e, #f3b63f);
+    --rewardx-highlight-silver: linear-gradient(135deg, #eef1f6, #c3c8d6);
+    --rewardx-highlight-bronze: linear-gradient(135deg, #f3c7a2, #d28c4a);
+    --rewardx-radius: 20px;
+    --rewardx-gap: clamp(12px, 3vw, 20px);
 }
 
 .rewardx-top-customers {
-    --gap: clamp(16px, 4vw, 28px);
-    position: relative;
+    max-width: min(960px, 95vw);
     margin: 0 auto;
     padding: clamp(20px, 5vw, 32px);
-    border-radius: 28px;
-    background: linear-gradient(135deg, var(--rewardx-gradient-start), var(--rewardx-gradient-end));
-    overflow: hidden;
-    color: #fff;
-    max-width: min(960px, 96vw);
-    box-shadow: 0 20px 45px rgba(64, 51, 144, 0.22);
-    isolation: isolate;
-}
-
-.rewardx-top-customers::before,
-.rewardx-top-customers::after {
-    content: "";
-    position: absolute;
-    inset: auto;
-    border-radius: 50%;
-    filter: blur(0);
-    opacity: 0.25;
-    z-index: -1;
-}
-
-.rewardx-top-customers::before {
-    width: clamp(120px, 28vw, 220px);
-    height: clamp(120px, 28vw, 220px);
-    background: radial-gradient(circle at center, rgba(255, 255, 255, 0.75), transparent 65%);
-    top: -10%;
-    right: -6%;
-}
-
-.rewardx-top-customers::after {
-    width: clamp(160px, 32vw, 260px);
-    height: clamp(160px, 32vw, 260px);
-    background: radial-gradient(circle at center, rgba(10, 5, 42, 0.35), transparent 70%);
-    bottom: -18%;
-    left: -10%;
+    border-radius: var(--rewardx-radius);
+    background: var(--rewardx-surface);
+    box-shadow: 0 12px 40px rgba(21, 18, 41, 0.12);
+    border: 1px solid var(--rewardx-border);
+    color: var(--rewardx-text-dark);
 }
 
 .rewardx-top-customers__header {
     text-align: center;
-    margin-bottom: var(--gap);
+    margin-bottom: clamp(16px, 4vw, 24px);
 }
 
 .rewardx-top-customers__title {
-    font-size: clamp(1.4rem, 3vw, 2rem);
-    font-weight: 700;
-    letter-spacing: -0.015em;
     margin: 0;
+    font-size: clamp(1.35rem, 3vw, 1.9rem);
+    font-weight: 700;
+    letter-spacing: -0.01em;
+    text-wrap: balance;
 }
 
 .rewardx-top-customers__subtitle {
-    font-size: clamp(0.9rem, 2.2vw, 1.05rem);
-    color: rgba(255, 255, 255, 0.78);
-    margin-top: 8px;
+    margin: 10px auto 0;
+    max-width: 52ch;
+    font-size: clamp(0.92rem, 2.4vw, 1.05rem);
+    color: var(--rewardx-text-muted);
+    text-wrap: balance;
 }
 
 .rewardx-top-customers__list {
     list-style: none;
     margin: 0;
     padding: 0;
-    display: grid;
-    gap: clamp(10px, 2vw, 14px);
+    display: flex;
+    flex-direction: column;
+    gap: var(--rewardx-gap);
 }
 
 .rewardx-top-customers__item {
-    display: grid;
-    grid-template-columns: auto 1fr auto;
+    display: flex;
     align-items: center;
-    gap: clamp(12px, 2.4vw, 16px);
-    padding: clamp(14px, 3vw, 18px);
-    border-radius: 18px;
-    background: var(--rewardx-card-bg);
-    border: 1px solid var(--rewardx-card-border);
-    backdrop-filter: blur(6px);
-    color: var(--rewardx-text-dark);
+    gap: clamp(12px, 3vw, 20px);
+    padding: clamp(14px, 3vw, 20px);
+    border-radius: calc(var(--rewardx-radius) - 6px);
+    background: var(--rewardx-surface-muted);
+    border: 1px solid var(--rewardx-border);
+    box-shadow: 0 4px 12px rgba(23, 20, 44, 0.08);
     transition: transform 0.2s ease, box-shadow 0.2s ease;
+    min-height: 72px;
 }
 
 .rewardx-top-customers__item:hover {
     transform: translateY(-2px);
-    box-shadow: 0 14px 28px rgba(34, 25, 78, 0.2);
+    box-shadow: 0 18px 28px rgba(23, 20, 44, 0.14);
 }
 
 .rewardx-top-customers__rank {
-    width: clamp(38px, 9vw, 52px);
-    height: clamp(38px, 9vw, 52px);
-    border-radius: 16px;
+    flex: 0 0 clamp(40px, 10vw, 52px);
+    height: clamp(40px, 10vw, 52px);
+    border-radius: 14px;
     display: grid;
     place-items: center;
     font-weight: 700;
@@ -109,38 +83,49 @@
 }
 
 .rewardx-top-customers__item--gold .rewardx-top-customers__rank {
-    background: linear-gradient(135deg, #f8d57e, #f3b63f);
+    background: var(--rewardx-highlight-gold);
 }
 
 .rewardx-top-customers__item--silver .rewardx-top-customers__rank {
-    background: linear-gradient(135deg, #e5e7ef, #c3c8d6);
+    background: var(--rewardx-highlight-silver);
 }
 
 .rewardx-top-customers__item--bronze .rewardx-top-customers__rank {
-    background: linear-gradient(135deg, #f3c7a2, #d28c4a);
+    background: var(--rewardx-highlight-bronze);
 }
 
 .rewardx-top-customers__info {
+    flex: 1 1 220px;
+    min-width: 0;
     display: grid;
     gap: 4px;
 }
 
 .rewardx-top-customers__name {
+    margin: 0;
     font-weight: 600;
     font-size: clamp(1rem, 2.5vw, 1.15rem);
     color: var(--rewardx-text-dark);
-    margin: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .rewardx-top-customers__meta {
-    font-size: clamp(0.85rem, 2.2vw, 0.95rem);
+    font-size: clamp(0.85rem, 2.2vw, 0.98rem);
     color: var(--rewardx-text-muted);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .rewardx-top-customers__value {
+    margin-left: auto;
     font-weight: 700;
-    font-size: clamp(1rem, 2.5vw, 1.15rem);
+    font-size: clamp(1rem, 2.5vw, 1.16rem);
     color: var(--rewardx-text-dark);
+    text-align: right;
+    white-space: nowrap;
 }
 
 .rewardx-top-customers__value--points {
@@ -152,54 +137,66 @@
     place-items: center;
     min-height: clamp(160px, 35vw, 220px);
     text-align: center;
-    background: linear-gradient(135deg, rgba(255, 255, 255, 0.1), rgba(10, 5, 42, 0.2));
+    background: var(--rewardx-surface);
+    border-radius: var(--rewardx-radius);
+    border: 1px dashed var(--rewardx-border);
+    padding: clamp(24px, 6vw, 40px);
 }
 
 .rewardx-top-customers__empty {
     margin: 0;
     font-size: clamp(0.95rem, 2.4vw, 1.1rem);
-    color: rgba(255, 255, 255, 0.85);
+    color: var(--rewardx-text-muted);
 }
 
-@media (max-width: 768px) {
+@media (max-width: 820px) {
     .rewardx-top-customers {
-        border-radius: 24px;
+        padding: clamp(18px, 6vw, 26px);
+        border-radius: calc(var(--rewardx-radius) - 2px);
     }
 
     .rewardx-top-customers__item {
-        grid-template-columns: auto 1fr;
-        grid-template-areas:
-            "rank name"
-            "rank meta"
-            "rank value";
-        align-items: start;
+        align-items: flex-start;
+        min-height: 0;
+    }
+}
+
+@media (max-width: 600px) {
+    .rewardx-top-customers__item {
+        flex-wrap: wrap;
+        row-gap: 10px;
     }
 
     .rewardx-top-customers__rank {
-        grid-area: rank;
+        flex: 0 0 40px;
     }
 
     .rewardx-top-customers__info {
-        grid-area: name;
-    }
-
-    .rewardx-top-customers__meta {
-        grid-area: meta;
+        flex: 1 1 calc(100% - 56px);
     }
 
     .rewardx-top-customers__value {
-        grid-area: value;
-        justify-self: start;
-        margin-top: 4px;
+        width: 100%;
+        margin-left: 0;
+        text-align: left;
+        padding-top: 2px;
     }
 }
 
-@media (max-width: 520px) {
+@media (max-width: 420px) {
     .rewardx-top-customers {
-        padding: clamp(18px, 6vw, 22px);
+        padding: clamp(16px, 7vw, 22px);
     }
 
     .rewardx-top-customers__item {
-        padding: clamp(12px, 5vw, 16px);
+        padding: clamp(12px, 6vw, 16px);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .rewardx-top-customers__item,
+    .rewardx-top-customers__item:hover {
+        transition: none;
+        transform: none;
     }
 }

--- a/includes/Frontend/class-frontend.php
+++ b/includes/Frontend/class-frontend.php
@@ -146,10 +146,7 @@ class Frontend
             $limit = 20;
         }
 
-        $all_customers = [];
-        $customers     = $this->get_top_customers($limit, $all_customers);
-
-        $this->log_top_customers_data($all_customers, $customers, $limit);
+        $customers = $this->get_top_customers($limit);
 
         wp_enqueue_style('rewardx-top-customers');
 
@@ -260,11 +257,9 @@ class Frontend
     }
 
     /**
-     * @param array<int, array{name: string, meta: string, total_spent: float, metric: string}>|null $all_customers
-     *
      * @return array<int, array{name: string, meta: string, total_spent: float, metric: string}>
      */
-    private function get_top_customers(int $limit = 20, ?array &$all_customers = null): array
+    private function get_top_customers(int $limit = 20): array
     {
         global $wpdb;
 
@@ -727,10 +722,6 @@ class Frontend
 
         $customers = array_values($customers);
 
-        if (is_array($all_customers)) {
-            $all_customers = $customers;
-        }
-
         return array_slice($customers, 0, $limit);
     }
 
@@ -818,31 +809,6 @@ class Frontend
         }
 
         return 'anon:' . md5(sprintf('%.2f', $total_spent));
-    }
-
-    private function log_top_customers_data(array $all_customers, array $top_customers, int $limit): void
-    {
-        $encoding_options = defined('JSON_UNESCAPED_UNICODE') ? JSON_UNESCAPED_UNICODE : 0;
-
-        $all_encoded = function_exists('wp_json_encode')
-            ? wp_json_encode($all_customers, $encoding_options)
-            : json_encode($all_customers, $encoding_options);
-
-        if (false === $all_encoded || null === $all_encoded) {
-            $all_encoded = print_r($all_customers, true);
-        }
-
-        error_log(sprintf('[RewardX] All customers for leaderboard (count %d): %s', count($all_customers), $all_encoded));
-
-        $top_encoded = function_exists('wp_json_encode')
-            ? wp_json_encode($top_customers, $encoding_options)
-            : json_encode($top_customers, $encoding_options);
-
-        if (false === $top_encoded || null === $top_encoded) {
-            $top_encoded = print_r($top_customers, true);
-        }
-
-        error_log(sprintf('[RewardX] Top customers (limit %d, count %d): %s', $limit, count($top_customers), $top_encoded));
     }
 
     private function database_table_exists(string $table): bool


### PR DESCRIPTION
## Summary
- redesign the ranking widget styles for a cleaner, responsive layout
- simplify leaderboard rendering by removing unused data collection and debug logging

## Testing
- php -l includes/Frontend/class-frontend.php

------
https://chatgpt.com/codex/tasks/task_e_68dad5434238832b8c4bf56e50292602