### PR TITLE
Refine mobile-first NFC profile presentation

### DIFF
--- a/assets/css/rewardx-nfc.css
+++ b/assets/css/rewardx-nfc.css
@@ -1,246 +1,232 @@
 body.rewardx-nfc-page {
     margin: 0;
     min-height: 100vh;
-    background: radial-gradient(circle at 20% 15%, rgba(59, 130, 246, 0.26), transparent 55%),
-        radial-gradient(circle at 80% 10%, rgba(14, 165, 233, 0.18), transparent 65%),
-        radial-gradient(circle at 20% 80%, rgba(34, 197, 94, 0.2), transparent 60%),
-        #0f172a;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+    background: #f8fafc;
     font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-    color: var(--rx-ink, #0f172a);
+    color: #0f172a;
+    line-height: 1.5;
 }
 
 .rewardx-nfc-container {
-    width: min(1040px, 92vw);
-    margin: 4.5rem auto;
+    width: 100%;
+    max-width: 560px;
+    margin: 0 auto;
+    padding: 1.75rem 1.25rem 2.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
 }
 
 .rewardx-nfc-header {
-    text-align: center;
-    color: #e2e8f0;
-    margin-bottom: 2.5rem;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    color: inherit;
+}
+
+.rewardx-nfc-header::before {
+    content: '';
+    display: block;
+    width: 0.35rem;
+    height: 2.2rem;
+    border-radius: 999px;
+    background: #2563eb;
 }
 
 .rewardx-nfc-header h1 {
-    margin: 0.35rem 0 0;
-    font-size: clamp(1.9rem, 1.6rem + 1.1vw, 2.7rem);
+    margin: 0;
+    font-size: 1.45rem;
     font-weight: 700;
-}
-
-.rewardx-nfc-header p {
-    margin: 0.35rem auto 0;
-    color: rgba(226, 232, 240, 0.88);
-    font-size: 1rem;
-    max-width: 520px;
+    letter-spacing: -0.01em;
 }
 
 .rewardx-nfc-account {
-    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
 }
 
 .rewardx-nfc-hero {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-    gap: 1.5rem;
-    margin: 0 0 2.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
 }
 
 .rewardx-nfc-identity,
 .rewardx-nfc-hero-card {
-    border-radius: 22px;
-    border: 1px solid var(--rx-border, rgba(148, 163, 184, 0.35));
-    box-shadow: var(--rx-shadow, 0 24px 55px rgba(15, 23, 42, 0.12));
-    position: relative;
-    overflow: hidden;
-    isolation: isolate;
-    background: var(--rx-surface, rgba(255, 255, 255, 0.95));
-    padding: 1.9rem 2rem;
-    display: grid;
+    background: #ffffff;
+    border: 1px solid rgba(148, 163, 184, 0.4);
+    border-radius: 16px;
+    padding: 1.4rem 1.5rem;
+    box-shadow: 0 8px 22px rgba(15, 23, 42, 0.08);
+    display: flex;
+    flex-direction: column;
     gap: 0.75rem;
-}
-
-.rewardx-nfc-identity::after,
-.rewardx-nfc-hero-card::after {
-    content: '';
-    position: absolute;
-    inset: 0;
-    background: radial-gradient(120% 120% at 0% 0%, rgba(37, 99, 235, 0.12), transparent 65%);
-    opacity: 0.85;
-    z-index: -1;
-}
-
-.rewardx-nfc-identity {
-    background: linear-gradient(140deg, rgba(255, 255, 255, 0.96), rgba(239, 246, 255, 0.96));
-    gap: 0.85rem;
-}
-
-.rewardx-nfc-identity::after {
-    background: radial-gradient(120% 120% at 0% 0%, rgba(59, 130, 246, 0.18), transparent 70%);
 }
 
 .rewardx-nfc-eyebrow {
     font-size: 0.75rem;
     letter-spacing: 0.16em;
     text-transform: uppercase;
-    color: var(--rx-accent, #2563eb);
+    color: #2563eb;
     font-weight: 600;
 }
 
 .rewardx-nfc-name {
     margin: 0;
-    font-size: clamp(1.75rem, 1.35rem + 1.4vw, 2.45rem);
+    font-size: 1.65rem;
     font-weight: 700;
-    color: var(--rx-ink, #0f172a);
 }
 
 .rewardx-nfc-rank-badge {
     display: inline-flex;
     align-items: center;
-    gap: 0.4rem;
-    padding: 0.4rem 0.85rem;
+    gap: 0.35rem;
+    padding: 0.35rem 0.75rem;
     border-radius: 999px;
-    background: var(--rx-accent-soft, rgba(37, 99, 235, 0.08));
-    color: var(--rx-accent, #2563eb);
-    font-size: 0.85rem;
+    background: rgba(37, 99, 235, 0.12);
+    color: #1d4ed8;
+    font-size: 0.82rem;
     font-weight: 600;
-    letter-spacing: 0.04em;
-}
-
-.rewardx-nfc-rank-meta {
-    font-size: 0.9rem;
-    color: var(--rx-muted, #64748b);
 }
 
 .rewardx-nfc-hero-card {
-    background: linear-gradient(135deg, rgba(37, 99, 235, 0.1), rgba(14, 165, 233, 0.08));
-    align-content: start;
-}
-
-.rewardx-nfc-hero-card::after {
-    opacity: 1;
+    gap: 0.5rem;
 }
 
 .rewardx-nfc-hero-label {
-    font-size: 0.82rem;
+    font-size: 0.78rem;
     text-transform: uppercase;
     letter-spacing: 0.14em;
-    color: var(--rx-muted-soft, #94a3b8);
+    color: #64748b;
     font-weight: 600;
 }
 
 .rewardx-nfc-hero-value {
-    font-size: clamp(2.3rem, 1.8rem + 1.2vw, 3rem);
+    font-size: 2.2rem;
     font-weight: 700;
-    color: var(--rx-accent, #2563eb);
+    color: #1d4ed8;
     margin: 0;
 }
 
 .rewardx-nfc-hero-note {
-    font-size: 0.95rem;
-    color: var(--rx-muted, #64748b);
-    line-height: 1.5;
+    font-size: 0.9rem;
+    color: #475569;
 }
 
-.rewardx-nfc-account .rewardx-summary-list {
-    gap: 1.1rem;
+.rewardx-summary {
+    display: flex;
+    flex-direction: column;
 }
 
-.rewardx-nfc-account .rewardx-summary-list li {
-    background: var(--rx-surface, rgba(255, 255, 255, 0.94));
-    border: 1px solid var(--rx-border, rgba(148, 163, 184, 0.35));
-    box-shadow: var(--rx-shadow, 0 20px 45px rgba(15, 23, 42, 0.12));
-    border-radius: 18px;
-    padding: 1.1rem 1.35rem;
+.rewardx-summary-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
     display: grid;
-    gap: 0.4rem;
-    position: relative;
-    overflow: hidden;
+    gap: 0.9rem;
 }
 
-.rewardx-nfc-account .rewardx-summary-list li::after {
-    content: '';
-    position: absolute;
-    inset: 0;
-    background: radial-gradient(120% 120% at 0% 0%, rgba(37, 99, 235, 0.08), transparent 70%);
-    opacity: 0.75;
-    z-index: -1;
+.rewardx-summary-list li {
+    background: #ffffff;
+    border-radius: 14px;
+    border: 1px solid rgba(148, 163, 184, 0.4);
+    padding: 1rem 1.25rem;
+    box-shadow: 0 6px 18px rgba(15, 23, 42, 0.07);
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
 }
 
-.rewardx-nfc-account .rewardx-summary-value {
-    font-size: 1.45rem;
+.rewardx-summary-label {
+    font-size: 0.85rem;
+    color: #64748b;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+}
+
+.rewardx-summary-value {
+    font-size: 1.35rem;
+    font-weight: 600;
 }
 
 .rewardx-summary-subtext {
     font-size: 0.85rem;
-    color: var(--rx-muted, #64748b);
+    color: #475569;
 }
 
 .rewardx-nfc-ocg {
-    margin-top: 2.75rem;
-    padding: 1.6rem 1.8rem;
-    border-radius: 22px;
-    background: linear-gradient(135deg, rgba(16, 185, 129, 0.18), rgba(34, 197, 94, 0.24));
-    border: 1px solid rgba(74, 222, 128, 0.45);
-    box-shadow: var(--rx-shadow, 0 20px 45px rgba(15, 23, 42, 0.12));
-    color: #064e3b;
-    display: grid;
-    gap: 0.6rem;
+    background: #ecfdf5;
+    border: 1px solid #bbf7d0;
+    border-radius: 16px;
+    padding: 1.3rem 1.4rem;
+    color: #065f46;
+    box-shadow: 0 6px 18px rgba(15, 23, 42, 0.07);
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
 }
 
 .rewardx-nfc-ocg.is-expired {
-    background: linear-gradient(135deg, rgba(248, 113, 113, 0.32), rgba(239, 68, 68, 0.28));
-    border-color: rgba(248, 113, 113, 0.45);
+    background: #fef2f2;
+    border-color: #fecaca;
     color: #7f1d1d;
 }
 
 .rewardx-nfc-ocg h2 {
     margin: 0;
-    font-size: 1.35rem;
+    font-size: 1.2rem;
     font-weight: 600;
 }
 
 .rewardx-nfc-ocg p {
     margin: 0;
-    font-size: 1rem;
-    line-height: 1.6;
+    font-size: 0.95rem;
 }
 
 .rewardx-nfc-empty {
+    color: #0f172a;
     text-align: center;
-    color: #e2e8f0;
+    padding: 3rem 1.5rem;
 }
 
 .rewardx-nfc-empty h1 {
-    font-size: clamp(1.6rem, 1.35rem + 1.1vw, 2.4rem);
-    margin-bottom: 0.75rem;
+    margin: 0 0 0.75rem;
+    font-size: 1.6rem;
 }
 
 .rewardx-nfc-empty p {
     margin: 0;
-    color: rgba(226, 232, 240, 0.85);
+    color: #475569;
 }
 
-@media (max-width: 720px) {
+@media (min-width: 640px) {
     .rewardx-nfc-container {
-        margin: 3.5rem auto;
+        padding: 2rem 1.75rem 3rem;
     }
 
-    .rewardx-nfc-header p {
-        font-size: 0.95rem;
+    .rewardx-nfc-hero {
+        flex-direction: row;
     }
 
     .rewardx-nfc-identity,
     .rewardx-nfc-hero-card {
-        padding: 1.65rem 1.55rem;
+        flex: 1 1 0;
+    }
+}
+
+@media (min-width: 768px) {
+    body.rewardx-nfc-page {
+        background: linear-gradient(180deg, #f8fafc 0%, #e2e8f0 100%);
     }
 
-    .rewardx-nfc-account .rewardx-summary-list {
-        gap: 0.75rem;
+    .rewardx-summary-list {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
     }
+}
 
-    .rewardx-nfc-account .rewardx-summary-list li {
-        padding: 1rem 1.1rem;
+@media (min-width: 1024px) {
+    .rewardx-summary-list {
+        grid-template-columns: repeat(4, minmax(0, 1fr));
     }
 }

--- a/includes/views/nfc-profile.php
+++ b/includes/views/nfc-profile.php
@@ -36,7 +36,6 @@ $error_message = $error_message ?? null;
         ?>
         <header class="rewardx-nfc-header">
             <h1><?php esc_html_e('Hồ sơ thành viên Peopo Loyalty', 'woo-rewardx-lite'); ?></h1>
-            <p><?php esc_html_e('Thông tin tóm tắt được hiển thị khi quét thẻ NFC của khách hàng.', 'woo-rewardx-lite'); ?></p>
         </header>
 
         <section class="rewardx-account rewardx-nfc-account">
@@ -54,17 +53,6 @@ $error_message = $error_message ?? null;
                     </h2>
                     <?php if ('' !== $rank_name) : ?>
                         <span class="rewardx-nfc-rank-badge"><?php echo esc_html($rank_name); ?></span>
-                    <?php endif; ?>
-                    <?php if ($rank_no && $rank_total) : ?>
-                        <span class="rewardx-nfc-rank-meta">
-                            <?php
-                            printf(
-                                esc_html__('Thứ tự hiện tại: %1$d / %2$d thành viên', 'woo-rewardx-lite'),
-                                $rank_no,
-                                $rank_total
-                            );
-                            ?>
-                        </span>
                     <?php endif; ?>
                 </article>
 


### PR DESCRIPTION
## Summary
- remove the extra helper copy and rank order text from the NFC member profile header
- restyle the NFC profile view with a mobile-first card layout instead of the previous jumbotron treatment

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68f106f42fb4832b9f10299c0522f197