### PR TITLE
Optimize loyalty account desktop layout

### DIFF
--- a/assets/css/rewardx.css
+++ b/assets/css/rewardx.css
@@ -592,6 +592,31 @@
     }
 }
 
+@media (min-width: 1280px) {
+    .rewardx-account {
+        max-width: 1280px;
+        padding: 3rem 3.5rem 4rem;
+    }
+
+    .rewardx-summary-list {
+        gap: 1rem 1.5rem;
+    }
+
+    .rewardx-summary-list li {
+        flex: 1 1 260px;
+    }
+
+    .rewardx-card-grid {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 1.5rem;
+    }
+
+    .rewardx-grid {
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        gap: 1.5rem;
+    }
+}
+
 .rewardx-card::before {
     content: '';
     position: absolute;


### PR DESCRIPTION
## Summary
- expand the loyalty account container and spacing on wide screens for improved desktop readability
- show more reward cards per row on large viewports while keeping mobile-first defaults intact

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f108856a08832b93d28927a0040d0f